### PR TITLE
set hostname for development/Vagrantfile.1.0 as required by provisioning

### DIFF
--- a/development/Vagrantfile.1.0
+++ b/development/Vagrantfile.1.0
@@ -12,8 +12,9 @@ def local_cache(box_name)
 end
 
 Vagrant::Config.run do |config|
-  config.vm.box     = "quantal64"
-  config.vm.box_url = "https://github.com/downloads/roderik/VagrantQuantal64Box/quantal64.box"
+  config.vm.box       = "quantal64"
+  config.vm.box_url   = "https://github.com/downloads/roderik/VagrantQuantal64Box/quantal64.box"
+  config.vm.host_name = 'lxc-dev-box'
 
   cache_dir = local_cache(config.vm.box)
   config.vm.share_folder "v-root",  "/vagrant", "../"


### PR DESCRIPTION
In a fresh checkout:

```
$ ( cd development; ln -s Vagrantfile{.1.0,}; vagrant up )
```

Was failing with:

```
err: /Stage[main]//Exec[config-lxc]/returns: change from notrun to 0
failed: cp /vagrant/development/lxc-configs/quantal64 /etc/default/lxc
returned 1 instead of one of [0] at
/tmp/vagrant-puppet/manifests/site.pp:19
```

because the hostname was "quantal64" and the puppet manifest attempts to
install the lxc-config based on the hostname name of the VM.

I also think the instructions from the README.md need review as the only way I was getting it to work in the 1.0 VM was to:

```
vagrant ssh
sudo bundle install
bundle exec vagrant-lxc init # then modify it to suit lxc
bundle exec vagrant-lxc up --provider=lxc
```

p.s. still just trying to catch up with everything you've done at this point, keep up the great work :)
