### PR TITLE
Fix default group on the rake task.

### DIFF
--- a/tasks/boxes.rake
+++ b/tasks/boxes.rake
@@ -97,7 +97,7 @@ class BuildGenericBoxTask < ::Rake::TaskLib
     run 'cleanup'
     sh 'sudo rm -f rootfs.tar.gz'
     sh 'sudo tar --numeric-owner -czf rootfs.tar.gz ./rootfs/*'
-    sh "sudo chown #{ENV['USER']}:#{ENV['USER']} rootfs.tar.gz"
+    sh "sudo chown #{ENV['USER']}:#{`id -gn`.strip} rootfs.tar.gz"
     sh "cp #{pwd}/boxes/#{@distrib}/lxc-template ."
     compile_metadata(pwd)
   end


### PR DESCRIPTION
On Archlinux, and probably other distributions, the _chown_ part in the rake boxes task doesn't work because the default group is not the 'username' but 'users'.

This change the way we retrieve the default group by using id.
