### PR TITLE
error while compressing container's rootfs 

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -100,16 +100,14 @@ module Vagrant
 
       # TODO: This needs to be reviewed and specs needs to be written
       def compress_rootfs
-        rootfs_dirname = File.dirname rootfs_path
-        basename       = rootfs_path.to_s.gsub(/^#{Regexp.escape rootfs_dirname}\//, '')
         # TODO: Pass in tmpdir so we can clean up from outside
         target_path    = "#{Dir.mktmpdir}/rootfs.tar.gz"
 
         Dir.chdir base_path do
           @logger.info "Compressing '#{rootfs_path}' rootfs to #{target_path}"
           @sudo_wrapper.run('rm', '-f', 'rootfs.tar.gz')
-          @sudo_wrapper.run('tar', '--numeric-owner', '-czf', target_path, "#{basename}/*")
-
+          @sudo_wrapper.run('tar', '--numeric-owner', '-czf', target_path, '-C', rootfs_path.to_s, '.')
+          
           @logger.info "Changing rootfs tarbal owner"
           @sudo_wrapper.run('chown', "#{ENV['USER']}:#{ENV['USER']}", target_path)
         end


### PR DESCRIPTION
Tried to package a custom box, but got an error while taring the container's rootfs:

``` sh
vagrant@base:~$ VAGRANT_LOG=DEBUG vagrant package gameserver -o debian_squeeze.box
 INFO global: Vagrant version: 1.2.7
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/kernel_v1/plugin.rb
 INFO manager: Registered plugin: kernel
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/resume/plugin.rb
 INFO manager: Registered plugin: resume command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/reload/plugin.rb
 INFO manager: Registered plugin: reload command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/package/plugin.rb
 INFO manager: Registered plugin: package command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/up/plugin.rb
 INFO manager: Registered plugin: up command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/plugin/plugin.rb
 INFO manager: Registered plugin: plugin command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/init/plugin.rb
 INFO manager: Registered plugin: init command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/status/plugin.rb
 INFO manager: Registered plugin: status command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/ssh/plugin.rb
 INFO manager: Registered plugin: ssh command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/suspend/plugin.rb
 INFO manager: Registered plugin: suspend command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/help/plugin.rb
 INFO manager: Registered plugin: help command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/provision/plugin.rb
 INFO manager: Registered plugin: provision command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/ssh_config/plugin.rb
 INFO manager: Registered plugin: ssh-config command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/halt/plugin.rb
 INFO manager: Registered plugin: halt command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/destroy/plugin.rb
 INFO manager: Registered plugin: destroy command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/box/plugin.rb
 INFO manager: Registered plugin: box command
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/providers/virtualbox/plugin.rb
 INFO manager: Registered plugin: VirtualBox provider
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/communicators/ssh/plugin.rb
 INFO manager: Registered plugin: ssh communicator
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/provisioners/ansible/plugin.rb
 INFO manager: Registered plugin: ansible
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/provisioners/puppet/plugin.rb
 INFO manager: Registered plugin: puppet
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/provisioners/cfengine/plugin.rb
 INFO manager: Registered plugin: CFEngine Provisioner
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/provisioners/chef/plugin.rb
 INFO manager: Registered plugin: chef
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/provisioners/shell/plugin.rb
 INFO manager: Registered plugin: shell
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/arch/plugin.rb
 INFO manager: Registered plugin: Arch guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/suse/plugin.rb
 INFO manager: Registered plugin: SUSE guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/redhat/plugin.rb
 INFO manager: Registered plugin: RedHat guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/pld/plugin.rb
 INFO manager: Registered plugin: PLD Linux guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/debian/plugin.rb
 INFO manager: Registered plugin: Debian guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/fedora/plugin.rb
 INFO manager: Registered plugin: Fedora guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/linux/plugin.rb
 INFO manager: Registered plugin: Linux guest.
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/omnios/plugin.rb
 INFO manager: Registered plugin: OmniOS guest.
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/ubuntu/plugin.rb
 INFO manager: Registered plugin: Ubuntu guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/openbsd/plugin.rb
 INFO manager: Registered plugin: OpenBSD guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/gentoo/plugin.rb
 INFO manager: Registered plugin: Gentoo guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/solaris/plugin.rb
 INFO manager: Registered plugin: Solaris guest.
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/guests/freebsd/plugin.rb
 INFO manager: Registered plugin: FreeBSD guest
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/arch/plugin.rb
 INFO manager: Registered plugin: Arch host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/fedora/plugin.rb
 INFO manager: Registered plugin: Fedora host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/linux/plugin.rb
 INFO manager: Registered plugin: Linux host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/windows/plugin.rb
 INFO manager: Registered plugin: Windows host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/gentoo/plugin.rb
 INFO manager: Registered plugin: Gentoo host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/freebsd/plugin.rb
 INFO manager: Registered plugin: FreeBSD host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/bsd/plugin.rb
 INFO manager: Registered plugin: BSD host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/hosts/opensuse/plugin.rb
 INFO manager: Registered plugin: OpenSUSE host
DEBUG global: Loading core plugin: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/kernel_v2/plugin.rb
 INFO manager: Registered plugin: kernel
 INFO vagrant: `vagrant` invoked: ["package", "gameserver", "-o", "debian_squeeze.box"]
DEBUG vagrant: Creating Vagrant environment
 INFO environment: Environment initialized (#<Vagrant::Environment:0x000000019aeb50>)
 INFO environment:   - cwd: /home/vagrant
 INFO environment: Home path: /home/vagrant/.vagrant.d
 INFO environment: Local data path: /home/vagrant/.vagrant
DEBUG environment: Creating: /home/vagrant/.vagrant
DEBUG environment: Loading plugins from: /home/vagrant/.vagrant.d/plugins.json
 INFO environment: Loading plugin from JSON: vagrant-dnsmasq
 INFO manager: Registered plugin: vagrant-dnsmasq
 INFO environment: Loading plugin from JSON: vagrant-lxc
 INFO manager: Registered plugin: Linux Containers (LXC) provider
 INFO environment: Loading plugin from JSON: vagrant-omnibus
 INFO manager: Registered plugin: Omnibus
 INFO environment: Running hook: environment_load
 INFO environment: Initializing config...
 INFO loader: Set :default = "/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/config/default.rb"
DEBUG loader: Populating proc cache for "/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/config/default.rb"
DEBUG loader: Load procs for pathname: /opt/vagrant/embedded/gems/gems/vagrant-1.2.7/config/default.rb
 INFO loader: Set :root = #<Pathname:/home/vagrant/Vagrantfile>
DEBUG loader: Populating proc cache for #<Pathname:/home/vagrant/Vagrantfile>
DEBUG loader: Load procs for pathname: /home/vagrant/Vagrantfile
 INFO loader: Loading configuration in order: [:default, :home, :root]
DEBUG loader: Loading from: default (evaluating)
DEBUG loader: Loading from: root (evaluating)
DEBUG loader: Configuration loaded successfully, finalizing and returning
DEBUG hosts: Host path search classes: [VagrantPlugins::HostOpenSUSE::Host, VagrantPlugins::HostFedora::Host, VagrantPlugins::HostFreeBSD::Host, VagrantPlugins::HostArch::Host, VagrantPlugins::HostWindows::Host, VagrantPlugins::HostGentoo::Host, VagrantPlugins::HostBSD::Host, VagrantPlugins::HostLinux::Host]
 INFO hosts: Host class: VagrantPlugins::HostLinux::Host
 INFO runner: Preparing hooks for middleware sequence...
INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x00000001c8bf08>
 INFO cli: CLI: [] "package" ["gameserver", "-o", "debian_squeeze.box"]
DEBUG cli: Invoking command class: VagrantPlugins::CommandPackage::Command ["gameserver", "-o", "debian_squeeze.box"]
DEBUG command: package options: {:output=>"debian_squeeze.box"}
DEBUG command: Getting target VMs for command. Arguments:
DEBUG command:  -- names: "gameserver"
DEBUG command:  -- options: {:single_target=>true}
DEBUG command: Finding machine that match name: gameserver
 INFO command: Active machine found with name gameserver. Using provider: lxc
 INFO environment: Getting machine: gameserver (lxc)
 INFO environment: Uncached load of machine.
 INFO loader: Set :vm_gameserver = [["2", #<Proc:0x000000019a0668@/home/vagrant/Vagrantfile:88>]]
DEBUG loader: Populating proc cache for ["2", #<Proc:0x000000019a0668@/home/vagrant/Vagrantfile:88>]
 INFO loader: Loading configuration in order: [:default, :home, :root, :vm_gameserver]
DEBUG loader: Loading from: default (cache)
DEBUG loader: Loading from: root (cache)
DEBUG loader: Loading from: vm_gameserver (evaluating)
DEBUG provisioner: Provisioner defined: chef_client
DEBUG loader: Configuration loaded successfully, finalizing and returning
 INFO box_collection: Searching for box: debian_squeeze (lxc) in /home/vagrant/.vagrant.d/boxes/debian_squeeze/lxc/metadata.json
 INFO box_collection: Box found: debian_squeeze (lxc)
 INFO environment: Applying 1 provider overrides. Reloading config.
 INFO loader: Set :vm_gameserver_debian_squeeze_lxc = [["2", #<Proc:0x000000022c7138>]]
DEBUG loader: Populating proc cache for ["2", #<Proc:0x000000022c7138>]
 INFO loader: Loading configuration in order: [:default, nil, :home, :root, :vm_gameserver, :vm_gameserver_debian_squeeze_lxc]
DEBUG loader: Loading from: default (cache)
DEBUG loader: Loading from: root (cache)
DEBUG loader: Loading from: vm_gameserver (cache)
DEBUG loader: Loading from: vm_gameserver_debian_squeeze_lxc (evaluating)
DEBUG loader: Configuration loaded successfully, finalizing and returning
 INFO machine: Initializing machine: gameserver
 INFO machine:   - Provider: Vagrant::LXC::Provider
 INFO machine:   - Box: #<Vagrant::Box:0x000000024d8508>
 INFO machine:   - Data dir: /home/vagrant/.vagrant/machines/gameserver/lxc
DEBUG lxc: Instantiating the container for: "vagrant_gameserver-1376057349"
 INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-ls"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: vagrant_gameserver-1376057349
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: vagrant_gameserver-1376057349
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO command: With machine: gameserver (LXC (vagrant_gameserver-1376057349))
DEBUG command: Packaging VM: gameserver
 INFO machine: Calling action: package on provider LXC (vagrant_gameserver-1376057349)
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x00000001bb1268>
 INFO warden: Calling action: #<Vagrant::Action::Builtin::Call:0x00000001c234f8>
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x000000024de2c8>
 INFO warden: Calling action: #<Vagrant::LXC::Action::Created:0x000000024d7dd8>
 INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-info", "--name", "vagrant_gameserver-1376057349"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: state:   STOPPED
pid:        -1
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Warden:0x00000002515098>
 INFO warden: Calling action: #<Vagrant::Action::Builtin::Call:0x00000002516150>
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x000000020fff80>
 INFO warden: Calling action: #<Vagrant::LXC::Action::Created:0x0000000233e918>
 INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-info", "--name", "vagrant_gameserver-1376057349"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: state:   STOPPED
pid:        -1
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Warden:0x000000024e8b38>
 INFO warden: Calling action: #<Vagrant::LXC::Action::Disconnect:0x000000024e8ac0>
 INFO warden: Calling action: #<Vagrant::LXC::Action::ClearForwardedPorts:0x000000024e8a98>
 INFO warden: Calling action: #<Vagrant::LXC::Action::RemoveTemporaryFiles:0x0000000236dfb0>
 INFO warden: Calling action: #<Vagrant::Action::Builtin::Call:0x00000002903fd8>
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x0000000260bb28>
 INFO warden: Calling action: #<Vagrant::Action::Builtin::GracefulHalt:0x00000002b15fb0>
 INFO graceful_halt: Verifying source state of machine: :running
 INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-info", "--name", "vagrant_gameserver-1376057349"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: state:   STOPPED
pid:        -1
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO graceful_halt: Invalid source state, not halting: stopped
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Warden:0x000000028d8e78>
 INFO warden: Calling action: #<Vagrant::LXC::Action::ForcedHalt:0x000000028d8e00>
 INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-info", "--name", "vagrant_gameserver-1376057349"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: state:   STOPPED
pid:        -1
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-info", "--name", "vagrant_gameserver-1376057349"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: state:   STOPPED
pid:        -1
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
DEBUG remove_tmp_files: Removing temporary files
 INFO subprocess: Starting process: ["/usr/bin/sudo", "rm", "-rf", "/var/lib/lxc/vagrant_gameserver-1376057349/rootfs/tmp/*"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO warden: Calling action: #<Vagrant::LXC::Action::CompressRootFS:0x00000002516ab0>
 INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-info", "--name", "vagrant_gameserver-1376057349"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: state:   STOPPED
pid:        -1
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO interface: info: Compressing container's rootfs...
[gameserver] Compressing container's rootfs...
 INFO driver: Compressing '/var/lib/lxc/vagrant_gameserver-1376057349/rootfs' rootfs to /tmp/d20130811-8624-1ufi90v/rootfs.tar.gz
 INFO subprocess: Starting process: ["/usr/bin/sudo", "rm", "-f", "rootfs.tar.gz"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 0
 INFO subprocess: Starting process: ["/usr/bin/sudo", "tar", "--numeric-owner", "-czf", "/tmp/d20130811-8624-1ufi90v/rootfs.tar.gz", "rootfs/*"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stderr: tar:
DEBUG subprocess: stderr: rootfs/*: Cannot stat: No such file or directory
DEBUG subprocess: stderr: tar: Exiting with failure status due to previous errors
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 2
ERROR warden: Error occurred: There was an error executing ["sudo", "tar", "--numeric-owner", "-czf", "/tmp/d20130811-8624-1ufi90v/rootfs.tar.gz", "rootfs/*"]

For more information on the failure, enable detailed logging by setting
the environment variable VAGRANT_LOG to DEBUG.
 INFO warden: Beginning recovery process...
 INFO warden: Calling recover: #<Vagrant::LXC::Action::CompressRootFS:0x00000002516ab0>
 INFO warden: Calling recover: #<Vagrant::Action::Builtin::Call:0x00000002516150>
 INFO warden: Beginning recovery process...
 INFO warden: Calling recover: #<Vagrant::Action::Builtin::Call:0x00000002903fd8>
 INFO warden: Beginning recovery process...
 INFO warden: Recovery complete.
 INFO warden: Recovery complete.
 INFO warden: Recovery complete.
 INFO warden: Beginning recovery process...
 INFO warden: Recovery complete.
ERROR warden: Error occurred: There was an error executing ["sudo", "tar", "--numeric-owner", "-czf", "/tmp/d20130811-8624-1ufi90v/rootfs.tar.gz", "rootfs/*"]

For more information on the failure, enable detailed logging by setting
the environment variable VAGRANT_LOG to DEBUG.
 INFO warden: Beginning recovery process...
 INFO warden: Calling recover: #<Vagrant::Action::Builtin::Call:0x00000001c234f8>
 INFO warden: Beginning recovery process...
 INFO warden: Recovery complete.
 INFO warden: Recovery complete.
 INFO environment: Running hook: environment_unload
 INFO runner: Preparing hooks for middleware sequence...
 INFO runner: 1 hooks defined.
 INFO runner: Running action: #<Vagrant::Action::Builder:0x000000027d2e48>
ERROR vagrant: Vagrant experienced an error! Details:
ERROR vagrant: #<Vagrant::LXC::Errors::ExecuteError: There was an error executing ["sudo", "tar", "--numeric-owner", "-czf", "/tmp/d20130811-8624-1ufi90v/rootfs.tar.gz", "rootfs/*"]

For more information on the failure, enable detailed logging by setting
the environment variable VAGRANT_LOG to DEBUG.>
ERROR vagrant: There was an error executing ["sudo", "tar", "--numeric-owner", "-czf", "/tmp/d20130811-8624-1ufi90v/rootfs.tar.gz", "rootfs/*"]

For more information on the failure, enable detailed logging by setting
the environment variable VAGRANT_LOG to DEBUG.
ERROR vagrant: /home/vagrant/.vagrant.d/gems/gems/vagrant-lxc-0.5.0/lib/vagrant-lxc/sudo_wrapper.rb:54:in `block in execute'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/util/retryable.rb:17:in `retryable'
/home/vagrant/.vagrant.d/gems/gems/vagrant-lxc-0.5.0/lib/vagrant-lxc/sudo_wrapper.rb:44:in `execute'
/home/vagrant/.vagrant.d/gems/gems/vagrant-lxc-0.5.0/lib/vagrant-lxc/sudo_wrapper.rb:14:in `run'
/home/vagrant/.vagrant.d/gems/gems/vagrant-lxc-0.5.0/lib/vagrant-lxc/driver.rb:111:in `block in compress_rootfs'
/home/vagrant/.vagrant.d/gems/gems/vagrant-lxc-0.5.0/lib/vagrant-lxc/driver.rb:108:in `chdir'
/home/vagrant/.vagrant.d/gems/gems/vagrant-lxc-0.5.0/lib/vagrant-lxc/driver.rb:108:in `compress_rootfs'
/home/vagrant/.vagrant.d/gems/gems/vagrant-lxc-0.5.0/lib/vagrant-lxc/action/compress_rootfs.rb:15:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/builtin/call.rb:57:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/runner.rb:61:in `block in run'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/util/busy.rb:19:in `busy'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/runner.rb:61:in `run'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/builtin/call.rb:51:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/warden.rb:34:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/builder.rb:116:in `call'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/runner.rb:61:in `block in run'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/util/busy.rb:19:in `busy'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/action/runner.rb:61:in `run'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/machine.rb:147:in `action'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/package/command.rb:79:in `package_vm'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/package/command.rb:68:in `block in package_target'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/plugin/v2/command.rb:182:in `block in with_target_vms'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/plugin/v2/command.rb:180:in `each'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/plugin/v2/command.rb:180:in `with_target_vms'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/package/command.rb:66:in `package_target'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/plugins/commands/package/command.rb:40:in `execute'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/cli.rb:46:in `execute'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/lib/vagrant/environment.rb:478:in `cli'
/opt/vagrant/embedded/gems/gems/vagrant-1.2.7/bin/vagrant:84:in `<top (required)>'
/opt/vagrant/bin/../embedded/gems/bin/vagrant:23:in `load'
/opt/vagrant/bin/../embedded/gems/bin/vagrant:23:in `<main>'
 INFO interface: error: There was an error executing ["sudo", "tar", "--numeric-owner", "-czf", "/tmp/d20130811-8624-1ufi90v/rootfs.tar.gz", "rootfs/*"]

For more information on the failure, enable detailed logging by setting
the environment variable VAGRANT_LOG to DEBUG.
There was an error executing ["sudo", "tar", "--numeric-owner", "-czf", "/tmp/d20130811-8624-1ufi90v/rootfs.tar.gz", "rootfs/*"]

For more information on the failure, enable detailed logging by setting
the environment variable VAGRANT_LOG to DEBUG.
```

host: debian squeeze
lxc: 0.9.0
tar: 1.23
vagrant: 1.2.7
vagrant-lxc: 0.5.0
