### PR TITLE
container's / must be compressed under 'rootfs' dir

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -106,7 +106,7 @@ module Vagrant
         Dir.chdir base_path do
           @logger.info "Compressing '#{rootfs_path}' rootfs to #{target_path}"
           @sudo_wrapper.run('rm', '-f', 'rootfs.tar.gz')
-          @sudo_wrapper.run('tar', '--numeric-owner', '-czf', target_path, '-C', rootfs_path.to_s, '.')
+          @sudo_wrapper.run('tar', '--numeric-owner', '-czf', target_path, 'rootfs')
           
           @logger.info "Changing rootfs tarbal owner"
           @sudo_wrapper.run('chown', "#{ENV['USER']}:#{ENV['USER']}", target_path)


### PR DESCRIPTION
[131](https://github.com/fgrehm/vagrant-lxc/pull/131) creates a rootfs.tar.gz without 'rootfs' as parent directory. this should fix it.

could someone confirm this?
