### PR TITLE
use uid/gid for chowns.

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -4,6 +4,8 @@ require "vagrant/util/subprocess"
 require "vagrant-lxc/errors"
 require "vagrant-lxc/driver/cli"
 
+require "etc"
+
 module Vagrant
   module LXC
     class Driver
@@ -108,8 +110,11 @@ module Vagrant
           @sudo_wrapper.run('rm', '-f', 'rootfs.tar.gz')
           @sudo_wrapper.run('tar', '--numeric-owner', '-czf', target_path, 'rootfs')
           
-          @logger.info "Changing rootfs tarbal owner"
-          @sudo_wrapper.run('chown', "#{ENV['USER']}:#{ENV['USER']}", target_path)
+          @logger.info "Changing rootfs tarball owner"
+
+          user_details=Etc.getpwnam(Etc.getlogin)
+
+          @sudo_wrapper.run('chown', "#{user_details.uid}:#{user_details.gid}", target_path)
         end
 
         target_path


### PR DESCRIPTION
package fails if there isn't a group with the same name as the user. Also, if you've changed your primary group, then it will get it wrong. 

This change looks up the primary uid/gids from passwd for the user and uses those as the chown target instead. 
