### PR TITLE
if lxc is <= 0.8 and host is debian don't try lxc-attach for ip detection

### DIFF
--- a/lib/vagrant-lxc/action/fetch_ip_with_lxc_attach.rb
+++ b/lib/vagrant-lxc/action/fetch_ip_with_lxc_attach.rb
@@ -20,8 +20,9 @@ module Vagrant
 
           def assigned_ip(env)
             driver  = env[:machine].provider.driver
+            is_debian = system("cat /etc/issue | grep 'Debian'")
             version = driver.version.match(/^(\d+\.\d+)\./)[1].to_f
-            unless version >= 0.8
+            if version < 0.8 || (is_debian && version <= 0.8)
               @logger.debug "lxc version does not support the --namespaces argument to lxc-attach"
               return nil
             end


### PR DESCRIPTION
On debian using lxc 0.8 there's no point to wait for lxc-attach tries to timeout before falling back to dnsmasq leases.

Feel free to replace the ugly system(), I lack experience to come up with something better.
