### PR TITLE
Fix salt install on debian boxes

### DIFF
--- a/boxes/build-debian-box.sh
+++ b/boxes/build-debian-box.sh
@@ -124,7 +124,7 @@ if [ $PUPPET = 1 ]; then
 fi
 
 if [ $SALT = 1 ]; then
-  ./common/install-salt $ROOTFS
+  ./common/install-salt-debian $ROOTFS
 fi
 
 if [ $BABUSHKA = 1 ]; then

--- a/boxes/common/install-salt-debian
+++ b/boxes/common/install-salt-debian
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+set -e
+
+rootfs=$1
+
+echo "installing salt"
+
+if [ $SUITE == "squeeze" ]; then
+    SALT_SOURCE="deb http://debian.saltstack.com/debian squeeze-saltstack main\ndeb http://backports.debian.org/debian-backports squeeze-backports main contrib non-free"
+elif [ $SUITE == "sid" ]; then
+    SALT_SOURCE="deb http://debian.saltstack.com/debian unstable main"
+else
+    SALT_SOURCE="deb http://debian.saltstack.com/debian wheezy-saltstack main"
+fi
+
+cat > $rootfs/tmp/install-salt << EOF
+#!/bin/sh
+echo "$SALT_SOURCE" > /etc/apt/sources.list.d/saltstack.list
+wget -q -O- "http://debian.saltstack.com/debian-salt-team-joehealy.gpg.key" | apt-key add -
+apt-get update
+apt-get install -y salt-minion
+apt-get clean
+EOF
+
+chroot $rootfs sh /tmp/install-salt
+
+rm -rf $rootfs/tmp/*


### PR DESCRIPTION
The current `install-salt` script doesn't work for Debian boxes because it relies on an Ubuntu-specific command (`apt-add-repository`).
