### PR TITLE
Add ANSIBLE option to Debian+Ubuntu build scripts

### DIFF
--- a/boxes/build-debian-box.sh
+++ b/boxes/build-debian-box.sh
@@ -15,6 +15,7 @@ set -e
 #   $ PUPPET=1 sudo -E ./build-debian-box.sh DEBIAN_RELEASE
 #   $ SALT=1 sudo -E ./build-debian-box.sh DEBIAN_RELEASE
 #   $ BABUSHKA=1 sudo -E ./build-debian-box.sh DEBIAN_RELEASE
+#   $ ANSIBLE=1 sudo -E ./build-debian-box.sh DEBIAN_RELEASE
 
 ##################################################################################
 # 0 - Initial setup and sanity checks
@@ -33,6 +34,7 @@ CHEF=${CHEF:-0}
 PUPPET=${PUPPET:-0}
 SALT=${SALT:-0}
 BABUSHKA=${BABUSHKA:-0}
+ANSIBLE=${ANSIBLE:-0}
 
 # Path to files bundled with the box
 CWD=`readlink -f .`
@@ -129,6 +131,10 @@ fi
 
 if [ $BABUSHKA = 1 ]; then
   ./common/install-babushka $ROOTFS
+fi
+
+if [ $ANSIBLE = 1 ]; then
+  ./common/install-ansible $ROOTFS
 fi
 
 

--- a/boxes/build-ubuntu-box.sh
+++ b/boxes/build-ubuntu-box.sh
@@ -14,6 +14,7 @@ set -e
 #   $ PUPPET=1 sudo -E ./build-ubuntu-box.sh UBUNTU_RELEASE BOX_ARCH
 #   $ SALT=1 sudo -E ./build-ubuntu-box.sh UBUNTU_RELEASE BOX_ARCH
 #   $ BABUSHKA=1 sudo -E ./build-ubuntu-box.sh UBUNTU_RELEASE BOX_ARCH
+#   $ ANSIBLE=1 sudo -E ./build-ubuntu-box.sh UBUNTU_RELEASE BOX_ARCH
 
 ##################################################################################
 # 0 - Initial setup and sanity checks
@@ -32,6 +33,7 @@ CHEF=${CHEF:-0}
 PUPPET=${PUPPET:-0}
 SALT=${SALT:-0}
 BABUSHKA=${BABUSHKA:-0}
+ANSIBLE=${ANSIBLE:-0}
 
 # Path to files bundled with the box
 CWD=`readlink -f .`
@@ -114,6 +116,9 @@ if [ $BABUSHKA = 1 ]; then
   ./common/install-babushka $ROOTFS
 fi
 
+if [ $ANSIBLE = 1 ]; then
+  ./common/install-ansible $ROOTFS
+fi
 
 ##################################################################################
 # 6 - Free up some disk space

--- a/boxes/common/install-ansible
+++ b/boxes/common/install-ansible
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+set -e
+
+rootfs=$1
+
+echo "installing ansible"
+chroot $rootfs apt-get update
+chroot $rootfs apt-get install python-apt -y --force-yes
+
+rm -rf $rootfs/tmp/*


### PR DESCRIPTION
Ansible clients require the `python-apt` package to be installed in order to communicate with the host.  Eventually in future versions Ansible [will auto-install](https://github.com/ansible/ansible/issues/4079#issuecomment-24175465) this package if it is not found, but until then it is a hard requirement for it to be installed on the client.
