### PR TITLE
Improved Sudoers Configuration

### DIFF
--- a/boxes/build-debian-box.sh
+++ b/boxes/build-debian-box.sh
@@ -97,7 +97,7 @@ chroot ${ROOTFS} chown -R vagrant: /home/vagrant/.ssh
 chroot ${ROOTFS} apt-get install sudo -y --force-yes
 chroot ${ROOTFS} adduser vagrant sudo
 
-# Enable passwordless sudo for users under the "sudo" group
+# Enable passwordless sudo for the vagrant user
 echo "vagrant ALL=(ALL) NOPASSWD:ALL" > ${ROOTFS}/etc/sudoers.d/vagrant
 chmod 0440 ${ROOTFS}/etc/sudoers.d/vagrant
 

--- a/boxes/build-ubuntu-box.sh
+++ b/boxes/build-ubuntu-box.sh
@@ -80,7 +80,7 @@ mkdir -p ${ROOTFS}/home/vagrant/.ssh
 echo $VAGRANT_KEY > ${ROOTFS}/home/vagrant/.ssh/authorized_keys
 chroot ${ROOTFS} chown -R vagrant: /home/vagrant/.ssh
 
-# Enable passwordless sudo for users under the "sudo" group
+# Enable passwordless sudo for the vagrant user
 echo "vagrant ALL=(ALL) NOPASSWD:ALL" > ${ROOTFS}/etc/sudoers.d/vagrant
 chmod 0440 ${ROOTFS}/etc/sudoers.d/vagrant
 


### PR DESCRIPTION
1. Rather than give NOPASSWD sudo to everyone in the `sudo` group, create an entry specifically for the vagrant user.
2. NOPASSWD sudo wasn't set up properly for the vagrant user, commands like `sudo -u other-user ls` would still request a password 

<!---
@huboard:{"order":188.0,"custom_state":""}
-->
