### PR TITLE
Fixes

### DIFF
--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -69,6 +69,7 @@ module Vagrant
         end
 
         def stop
+          attach '/sbin/halt'
           run :stop, '--name', @name
         end
 


### PR DESCRIPTION
Hi Fábio,

vagrant-lxc is a great work, well done!

I've tried out vagrant-lxc on ubuntu 13.10 with ubuntu lxc ppa's.
vagrant status has shown the containers in unknown state, hence the first fix.
The other one was a very long waiting time for vagrant destroy.
I inserted a line to first shut down the container and then stop it.

Best regards,
  Attila
