### PR TITLE
Fix Ubuntu box build script sudoers syntax

### DIFF
--- a/boxes/build-ubuntu-box.sh
+++ b/boxes/build-ubuntu-box.sh
@@ -83,7 +83,7 @@ chroot ${ROOTFS} chown -R vagrant: /home/vagrant/.ssh
 # Enable passwordless sudo for users under the "sudo" group
 cp ${ROOTFS}/etc/sudoers{,.orig}
 sed -i -e \
-      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
+      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=\(ALL\) NOPASSWD:ALL/g' \
       ${ROOTFS}/etc/sudoers
 
 


### PR DESCRIPTION
When executing sudo -u inside the Ubuntu lxc vagrant box:

$ vagrant ssh
$ sudo -u vagrant ls 

I get this error: `Sorry, user vagrant is not allowed to execute '/bin/ls' as vagrant on <machine>.`

Googling about the message i found a similar issue in the vagrant repository: https://github.com/mitchellh/vagrant/issues/892

The solution is very simple, just a syntax fix in the build script that handles /etc/sudoers file.
