### PR TITLE
Fix matching pattern

### DIFF
--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -38,7 +38,7 @@ module Vagrant
         end
 
         def state
-          if @name && run(:info, '--name', @name, retryable: true) =~ /^state:[^A-Z]+([A-Z]+)$/
+          if @name && run(:info, '--name', @name, retryable: true) =~ /^state:[^A-Z]+([A-Z]+)$/i
             $1.downcase.to_sym
           elsif @name
             :unknown


### PR DESCRIPTION
Hi Fabio

I'm using lxc 'version: 1.0.0.alpha3'.
lxc-info's output is follow:
$ sudo lxc-info -n test_default-1387877096
Name:           test_default-1387877096
State:          RUNNING
....
So I fixed matching pattern is case insensitive.

Thanks.
Hiro
