### PR TITLE
Correct state detection for LXC 1.0

### DIFF
--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -38,7 +38,7 @@ module Vagrant
         end
 
         def state
-          if @name && run(:info, '--name', @name, retryable: true) =~ /^state:[^A-Z]+([A-Z]+)$/
+          if @name && run(:info, '--name', @name, retryable: true) =~ /^[Ss]tate:\s+([A-Z]+)$/
             $1.downcase.to_sym
           elsif @name
             :unknown


### PR DESCRIPTION
Hi,

I'm using vagrant-lxc with  lxc version: 1.0.0.alpha3
Due to changes in lxc-info output plugin can't properly detect container state.

===sample out===
lxc-info -n etbase-lxc-353-1387943533
Name:           etbase-lxc-353-1387943533
State:          RUNNING
PID:            14258
IP:             192.168.14.201
CPU use:        208.29 seconds
BlkIO use:      963.90 MiB
Memory use:     852.58 MiB
Link:           veth6841NO
 TX bytes:      10.29 MiB
 RX bytes:      92.95 MiB
 Total bytes:   103.24 MiB
