### PR TITLE
Support for naming containers from Vagrantfile

### DIFF
--- a/lib/vagrant-lxc/action/create.rb
+++ b/lib/vagrant-lxc/action/create.rb
@@ -7,9 +7,13 @@ module Vagrant
         end
 
         def call(env)
-          container_name = "#{env[:root_path].basename}_#{env[:machine].name}"
-          container_name.gsub!(/[^-a-z0-9_]/i, "")
-          container_name << "-#{Time.now.to_i}"
+          if env[:machine].provider_config.static_name
+            container_name = env[:machine].name.to_s
+          else
+            container_name = "#{env[:root_path].basename}_#{env[:machine].name}"
+            container_name.gsub!(/[^-a-z0-9_]/i, "")
+            container_name << "-#{Time.now.to_i}"
+          end
 
           env[:machine].provider.driver.create(
             container_name,

--- a/lib/vagrant-lxc/config.rb
+++ b/lib/vagrant-lxc/config.rb
@@ -12,9 +12,13 @@ module Vagrant
       # on /etc/sudoers
       attr_accessor :sudo_wrapper
 
+      # A String that sets a static name
+      attr_accessor :static_name
+
       def initialize
         @customizations = []
         @sudo_wrapper   = UNSET_VALUE
+        @static_name = UNSET_VALUE
       end
 
       # Customize the container by calling `lxc-start` with the given
@@ -34,6 +38,7 @@ module Vagrant
 
       def finalize!
         @sudo_wrapper = nil if @sudo_wrapper == UNSET_VALUE
+        @static_name = nil if @static_name == UNSET_VALUE
       end
 
       def validate(machine)


### PR DESCRIPTION
Here's an attempt at resolving fgrehm/vagrant-lxc#132

I don't have a check for pre-existing containers, but I don't know if that's necessary/how to implement it. lxc-create will throw an error if a container already exists, and vagrant already tracks the state of the "VMs" it creates.
