### PR TITLE
Fix apt-get error when building Ubuntu boxes

### DIFF
--- a/boxes/build-ubuntu-box.sh
+++ b/boxes/build-ubuntu-box.sh
@@ -91,6 +91,7 @@ sed -i -e \
 # 4 - Add some goodies and update packages
 
 PACKAGES=(vim curl wget man-db bash-completion)
+chroot ${ROOTFS} apt-get update
 chroot ${ROOTFS} apt-get install ${PACKAGES[*]} -y --force-yes
 chroot ${ROOTFS} apt-get upgrade -y --force-yes
 


### PR DESCRIPTION
I was getting an error when trying to build an Ubuntu Precise 64-bit box.  This is what I did to fix it, not sure if it's a proper fix or not but worked for me.

```
$ sudo -E ./build-ubuntu-box.sh precise amd64                                             

No config file specified, using the default config
debootstrap is /usr/sbin/debootstrap
Checking cache download in /var/cache/lxc/precise/rootfs-amd64 ... 
Copy /var/cache/lxc/precise/rootfs-amd64 to /var/lib/lxc/precise-base/rootfs ... 
Copying rootfs to /var/lib/lxc/precise-base/rootfs ...

##
# The default user is 'ubuntu' with password 'ubuntu'!
# Use the 'sudo' command to run tasks as root in the container.
##

'ubuntu' template installed
'precise-base' created
Reading package lists... Done
Building dependency tree       
Reading state information... Done
vim is already the newest version.
The following extra packages will be installed:
  bsdmainutils ca-certificates groff-base libasn1-8-heimdal libcurl3 libgcrypt11 libgdbm3 libgnutls26 libgpg-error0
  libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal libheimntlm0-heimdal libhx509-5-heimdal libidn11
  libkrb5-26-heimdal libldap-2.4-2 libp11-kit0 libpipeline1 libroken18-heimdal librtmp0 libsasl2-2 libsasl2-modules
  libtasn1-3 libwind0-heimdal openssl
Suggested packages:
  cpp wamerican wordlist whois vacation groff rng-tools gnutls-bin libsasl2-modules-otp libsasl2-modules-ldap
  libsasl2-modules-sql libsasl2-modules-gssapi-mit libsasl2-modules-gssapi-heimdal www-browser
The following NEW packages will be installed:
  bash-completion bsdmainutils ca-certificates curl groff-base libasn1-8-heimdal libcurl3 libgcrypt11 libgdbm3
  libgnutls26 libgpg-error0 libgssapi3-heimdal libhcrypto4-heimdal libheimbase1-heimdal libheimntlm0-heimdal
  libhx509-5-heimdal libidn11 libkrb5-26-heimdal libldap-2.4-2 libp11-kit0 libpipeline1 libroken18-heimdal librtmp0
  libsasl2-2 libsasl2-modules libtasn1-3 libwind0-heimdal man-db openssl wget
0 upgraded, 30 newly installed, 0 to remove and 0 not upgraded.
Need to get 5822 kB of archives.
After this operation, 15.5 MB of additional disk space will be used.
Get:1 http://archive.ubuntu.com/ubuntu/ precise-updates/main bash-completion all 1:1.3-1ubuntu8.1 [134 kB]
Get:2 http://archive.ubuntu.com/ubuntu/ precise-updates/main libroken18-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [46.0 kB]
Get:3 http://archive.ubuntu.com/ubuntu/ precise-updates/main libasn1-8-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [220 kB]
Get:4 http://archive.ubuntu.com/ubuntu/ precise/main libgpg-error0 amd64 1.10-2ubuntu1 [14.5 kB]
Get:5 http://archive.ubuntu.com/ubuntu/ precise-updates/main libgcrypt11 amd64 1.5.0-3ubuntu0.2 [280 kB]
Get:6 http://archive.ubuntu.com/ubuntu/ precise/main libgdbm3 amd64 1.8.3-10 [35.3 kB]
Get:7 http://archive.ubuntu.com/ubuntu/ precise/main libp11-kit0 amd64 0.12-2ubuntu1 [34.3 kB]
Get:8 http://archive.ubuntu.com/ubuntu/ precise-updates/main libtasn1-3 amd64 2.10-1ubuntu1.1 [43.3 kB]
Get:9 http://archive.ubuntu.com/ubuntu/ precise-updates/main libgnutls26 amd64 2.12.14-5ubuntu3.5 [459 kB]
Get:10 http://archive.ubuntu.com/ubuntu/ precise-updates/main libhcrypto4-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [103 kB]
Get:11 http://archive.ubuntu.com/ubuntu/ precise-updates/main libheimbase1-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [33.1 kB]
Get:12 http://archive.ubuntu.com/ubuntu/ precise-updates/main libwind0-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [77.8 kB]
Get:13 http://archive.ubuntu.com/ubuntu/ precise-updates/main libhx509-5-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [125 kB]
Get:14 http://archive.ubuntu.com/ubuntu/ precise-updates/main libkrb5-26-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [234 kB]
Get:15 http://archive.ubuntu.com/ubuntu/ precise-updates/main libheimntlm0-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [16.0 kB]
Get:16 http://archive.ubuntu.com/ubuntu/ precise-updates/main libgssapi3-heimdal amd64 1.6~git20120311.dfsg.1-2ubuntu0.1 [108 kB]
Get:17 http://archive.ubuntu.com/ubuntu/ precise/main libidn11 amd64 1.23-2 [112 kB]
Get:18 http://archive.ubuntu.com/ubuntu/ precise-updates/main libsasl2-2 amd64 2.1.25.dfsg1-3ubuntu0.1 [69.1 kB]
Get:19 http://archive.ubuntu.com/ubuntu/ precise-updates/main libldap-2.4-2 amd64 2.4.28-1.1ubuntu4.4 [185 kB]
Get:20 http://archive.ubuntu.com/ubuntu/ precise/main libpipeline1 amd64 1.2.1-1 [26.5 kB]
Get:21 http://archive.ubuntu.com/ubuntu/ precise/main librtmp0 amd64 2.4~20110711.gitc28f1bab-1 [57.1 kB]
Get:22 http://archive.ubuntu.com/ubuntu/ precise-updates/main openssl amd64 1.0.1-4ubuntu5.10 [524 kB]
Get:23 http://archive.ubuntu.com/ubuntu/ precise/main ca-certificates all 20111211 [169 kB]
Err http://archive.ubuntu.com/ubuntu/ precise-updates/main libcurl3 amd64 7.22.0-3ubuntu4.3
  404  Not Found [IP: 91.189.92.156 80]
Get:24 http://archive.ubuntu.com/ubuntu/ precise/main bsdmainutils amd64 8.2.3ubuntu1 [200 kB]
Get:25 http://archive.ubuntu.com/ubuntu/ precise/main groff-base amd64 1.21-7 [1046 kB]
Get:26 http://archive.ubuntu.com/ubuntu/ precise-updates/main libsasl2-modules amd64 2.1.25.dfsg1-3ubuntu0.1 [63.2 kB]
Get:27 http://archive.ubuntu.com/ubuntu/ precise-updates/main man-db amd64 2.6.1-2ubuntu1 [755 kB]
Get:28 http://archive.ubuntu.com/ubuntu/ precise/main wget amd64 1.13.4-2ubuntu1 [277 kB]
Err http://archive.ubuntu.com/ubuntu/ precise-updates/main curl amd64 7.22.0-3ubuntu4.3
  404  Not Found [IP: 91.189.92.156 80]
Fetched 5447 kB in 3s (1675 kB/s)
Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/curl/libcurl3_7.22.0-3ubuntu4.3_amd64.deb  404  Not Found [IP: 91.189.92.156 80]
Failed to fetch http://archive.ubuntu.com/ubuntu/pool/main/c/curl/curl_7.22.0-3ubuntu4.3_amd64.deb  404  Not Found [IP: 91.189.92.156 80]
E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?
```

<!---
@huboard:{"order":189.0,"custom_state":""}
-->
