### PR TITLE
Fix broken locale in Ubuntu boxes

### DIFF
--- a/boxes/build-ubuntu-box.sh
+++ b/boxes/build-ubuntu-box.sh
@@ -61,6 +61,10 @@ fi
 # See https://github.com/fgrehm/vagrant-lxc/issues/91 for more info
 echo 'ff02::3 ip6-allhosts' >> ${ROOTFS}/etc/hosts
 
+# Ensure locales are properly set, based on http://askubuntu.com/a/238063
+chroot ${ROOTFS} locale-gen en_US.UTF-8
+chroot ${ROOTFS} dpkg-reconfigure locales
+
 
 ##################################################################################
 # 2 - Prepare vagrant user


### PR DESCRIPTION
When trying to install Postgres on a freshly-built Ubuntu Precise 64-bit box, it was blowing up due to locale errors.  It appears that the locale is broken:

```
$ vagrant ssh
Welcome to Ubuntu 12.04.3 LTS (GNU/Linux 3.8.0-32-generic x86_64)

 * Documentation:  https://help.ubuntu.com/

The programs included with the Ubuntu system are free software;
the exact distribution terms for each program are described in the
individual files in /usr/share/doc/*/copyright.

Ubuntu comes with ABSOLUTELY NO WARRANTY, to the extent permitted by
applicable law.

vagrant@precise-base:~$ locale
locale: Cannot set LC_CTYPE to default locale: No such file or directory
locale: Cannot set LC_MESSAGES to default locale: No such file or directory
locale: Cannot set LC_ALL to default locale: No such file or directory
LANG=en_US.UTF-8
LANGUAGE=
LC_CTYPE=en_US.UTF-8
LC_NUMERIC="en_US.UTF-8"
LC_TIME="en_US.UTF-8"
LC_COLLATE="en_US.UTF-8"
LC_MONETARY="en_US.UTF-8"
LC_MESSAGES="en_US.UTF-8"
LC_PAPER="en_US.UTF-8"
LC_NAME="en_US.UTF-8"
LC_ADDRESS="en_US.UTF-8"
LC_TELEPHONE="en_US.UTF-8"
LC_MEASUREMENT="en_US.UTF-8"
LC_IDENTIFICATION="en_US.UTF-8"
LC_ALL=
```

When reading the build script output [before the fix](https://gist.github.com/abevoelker/8261510#file-before-locale-fix-txt), it does mention locale errors.  [After the fix](https://gist.github.com/abevoelker/8261510#file-after-locale-fix-txt), the locale errors are gone.

I'm not sure if it's a proper fix or not but worked for me.

<!---
@huboard:{"order":190.0,"custom_state":""}
-->
