### PR TITLE
Allow sudoers to run commands as any user (not only root) in box building scripts for debian/ubuntu

### DIFF
--- a/boxes/build-debian-box.sh
+++ b/boxes/build-debian-box.sh
@@ -100,7 +100,7 @@ chroot ${ROOTFS} adduser vagrant sudo
 # Enable passwordless sudo for users under the "sudo" group
 cp ${ROOTFS}/etc/sudoers{,.orig}
 sed -i -e \
-      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
+      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=(ALL)NOPASSWD:ALL/g' \
       ${ROOTFS}/etc/sudoers
 
 

--- a/boxes/build-ubuntu-box.sh
+++ b/boxes/build-ubuntu-box.sh
@@ -83,7 +83,7 @@ chroot ${ROOTFS} chown -R vagrant: /home/vagrant/.ssh
 # Enable passwordless sudo for users under the "sudo" group
 cp ${ROOTFS}/etc/sudoers{,.orig}
 sed -i -e \
-      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=NOPASSWD:ALL/g' \
+      's/%sudo\s\+ALL=(ALL\(:ALL\)\?)\s\+ALL/%sudo ALL=(ALL)NOPASSWD:ALL/g' \
       ${ROOTFS}/etc/sudoers
 
 


### PR DESCRIPTION
Current box building scripts setup sudoers file so it does not allow to run `sudo -u $USER cmd` without prompting for a password, which is important for e.g. PostgresSQL deployment scenarios.
