### PR TITLE
Fix lxc-info state regex for recent lxc versions

### DIFF
--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -38,7 +38,7 @@ module Vagrant
         end
 
         def state
-          if @name && run(:info, '--name', @name, retryable: true) =~ /^state:[^A-Z]+([A-Z]+)$/
+          if @name && run(:info, '--name', @name, retryable: true) =~ /^[sS]tate:\s*[^A-Z]+([A-Z]+)$/
             $1.downcase.to_sym
           elsif @name
             :unknown

--- a/spec/unit/driver/cli_spec.rb
+++ b/spec/unit/driver/cli_spec.rb
@@ -136,6 +136,24 @@ describe Vagrant::LXC::Driver::CLI do
     end
   end
 
+  describe 'state-new' do
+    let(:name) { 'a-container' }
+    subject    { described_class.new(sudo_wrapper, name) }
+
+    before do
+      subject.stub(:run).and_return("State:          RUNNING\nPID:            2")
+    end
+
+    it 'calls lxc-info with the right arguments' do
+      subject.state
+      subject.should have_received(:run).with(:info, '--name', name, retryable: true)
+    end
+
+    it 'maps the output of lxc-info status out to a symbol' do
+      subject.state.should == :running
+    end
+  end
+
   describe 'attach' do
     let(:name)           { 'a-running-container' }
     let(:command)        { ['ls', 'cat /tmp/file'] }


### PR DESCRIPTION
Recent versions of lxc-info (some pre-1.0 alpha or beta) use a different output format than prior versions (0.9).

Instead of

```
state:RUNNING
```

the output is now

```
State:          RUNNING
```

This patches adjusts the regex that parses this output to match both output formats and adds a unit test.

See the lxc code at https://github.com/lxc/lxc/blob/master/src/lxc/lxc_info.c#L303 for reference.
