### PR TITLE
Enable bash-completion as it's installed

### DIFF
--- a/boxes/build-debian-box.sh
+++ b/boxes/build-debian-box.sh
@@ -111,6 +111,10 @@ PACKAGES=(vim curl wget man-db bash-completion ca-certificates)
 chroot ${ROOTFS} apt-get install ${PACKAGES[*]} -y --force-yes
 chroot ${ROOTFS} apt-get upgrade -y --force-yes
 
+# Enable bash-completion
+sed -e '/^#if ! shopt -oq posix; then/,/^#fi/ s/^#\(.*\)/\1/g' \
+  -i ${ROOTFS}/etc/bash.bashrc
+
 
 ##################################################################################
 # 6 - Configuration management tools


### PR DESCRIPTION
Signed-off-by: Laurent Vallar val@zbla.net

As bash-completion is part of installed goodies, it should be enabled for all users.

<!---
@huboard:{"order":189.5,"custom_state":""}
-->
