### PR TITLE
Support current LANG environment variable if any.

### DIFF
--- a/boxes/build-debian-box.sh
+++ b/boxes/build-debian-box.sh
@@ -74,9 +74,10 @@ chroot $ROOTFS /usr/sbin/update-rc.d -f mountall-bootclean.sh remove
 chroot $ROOTFS /usr/sbin/update-rc.d -f mountnfs-bootclean.sh remove
 
 # Ensure locales are properly set, based on http://linux.livejournal.com/1880366.html
-sed -i "s/^# en_US/en_US/" ${ROOTFS}/etc/locale.gen
+LANG=${LANG:-en_US.UTF-8}
+sed -i "s/^# ${LANG}/${LANG}/" ${ROOTFS}/etc/locale.gen
 chroot $ROOTFS /usr/sbin/locale-gen
-chroot $ROOTFS update-locale LANG=en_US.UTF-8
+chroot $ROOTFS update-locale LANG=${LANG}
 
 
 ##################################################################################


### PR DESCRIPTION
Signed-off-by: Laurent Vallar val@zbla.net

Debian box locale configuration may follow builder's LANG environment variable.

<!---
@huboard:{"order":191.0,"custom_state":""}
-->
