### PR TITLE
Add support of lxc-info 1.0.0beta1.

### DIFF
--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -38,7 +38,7 @@ module Vagrant
         end
 
         def state
-          if @name && run(:info, '--name', @name, retryable: true) =~ /^state:[^A-Z]+([A-Z]+)$/
+          if @name && run(:info, '--name', @name, retryable: true) =~ /^state:[^A-Z]+([A-Z]+)$/i
             $1.downcase.to_sym
           elsif @name
             :unknown

--- a/spec/unit/driver/cli_spec.rb
+++ b/spec/unit/driver/cli_spec.rb
@@ -134,6 +134,11 @@ describe Vagrant::LXC::Driver::CLI do
     it 'maps the output of lxc-info status out to a symbol' do
       subject.state.should == :stopped
     end
+
+    it "maps the output of lxc-info v1.0.0" do
+      subject.stub(:run).and_return("State:     RUNNING\nPID:   2")
+      subject.state.should == :running
+    end
   end
 
   describe 'attach' do


### PR DESCRIPTION
I'm running a debian host with lxc1.0.0beta1 (from unstable).
Some commands fails because of the updated output of lxc-info.
I just updated the regexp to ignore case.

For history, here is the new output.

```
State:          RUNNING
PID:            2
IP:             192.168.x.x
CPU use:        xx seconds
Link:           vethxx
 TX bytes:      xx KiB
 RX bytes:      xx KiB
 Total bytes:   xx KiB
```
