### PR TITLE
remove naming cruft, clarify comment

### DIFF
--- a/lib/vagrant-lxc/config.rb
+++ b/lib/vagrant-lxc/config.rb
@@ -12,14 +12,13 @@ module Vagrant
       # on /etc/sudoers
       attr_accessor :sudo_wrapper
 
-      # A string to explicitly set the container name (use :machine) to set it
-      # to the corresponding machine name.
+      # A string to explicitly set the container name. To use the vagrant
+      # machine name, set this to :machine
       attr_accessor :container_name
 
       def initialize
         @customizations = []
         @sudo_wrapper   = UNSET_VALUE
-        @use_machine_name = UNSET_VALUE
         @container_name = UNSET_VALUE
       end
 
@@ -40,7 +39,6 @@ module Vagrant
 
       def finalize!
         @sudo_wrapper = nil if @sudo_wrapper == UNSET_VALUE
-        @use_machine_name = false if @use_machine_name == UNSET_VALUE
         @container_name = nil if @container_name == UNSET_VALUE
       end
 


### PR DESCRIPTION
Removed confusing leftover "use_machine_name" variable
Made comment about :container_name more clear
