### PR TITLE
Flexible mac address regex

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -40,7 +40,7 @@ module Vagrant
       end
 
       def mac_address
-        @mac_address ||= config_string.match(/^lxc\.network\.hwaddr\s+=\s+(.+)$/)[1]
+        @mac_address ||= config_string.match(/^lxc\.network\.hwaddr\s*+=\s*+(.+)$/)[1]
       end
 
       def config_string


### PR DESCRIPTION
Some of my templates have different spacing around the equals sign, and others might have this problem as well.
