### PR TITLE
boxes: Return in bash is only allowed in functions

### DIFF
--- a/boxes/common/lxc-template
+++ b/boxes/common/lxc-template
@@ -106,22 +106,19 @@ fi
 # Unpack the rootfs
 echo "Unpacking the rootfs"
 
-
 (
     flock -x 200
     if [ $? -ne 0 ]; then
         echo "Cache repository is busy."
-        return 1
+        exit 1
     fi
 
     mkdir -p ${LXC_ROOTFS}
     (cd ${LXC_ROOTFS} && tar xfz ${LXC_TARBALL} --strip-components=2)
     if [ $? -ne 0 ]; then
         echo "Failed to extract rootfs"
-        return 1
+        exit 1
     fi
-
-    return 0
 
 ) 200>/var/lock/subsys/lxc
 


### PR DESCRIPTION
I was trying out the new base box scripts on a Debian sid+experimental system with LXC 1.0.0. When I try to `vagrant up` a machine, `lxc-create` fails due to an error in the LXC template:

```
DEBUG driver: Creating container...
INFO subprocess: Starting process: ["/usr/bin/sudo", "lxc-create", "--template", "vagrant-tmp-infra_git_1394543261259_54013", "--name", "infra_git_1394543261259_54013", "--", "--tarball", "/home/fpletz/.vagrant.d/boxes/precise-amd64/lxc/rootfs.tar.gz", "--config", "/home/fpletz/.vagrant.d/boxes/precise-amd64/lxc/lxc-config"]
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stdout: Unpacking the rootfs
DEBUG subprocess: stderr: /usr/share/lxc/templates/lxc-vagrant-tmp-infra_git_1394543261259_54013: line 124: return: can only `return' from a function or sourced script
DEBUG subprocess: stderr: lxc_container: container creation template for infra_git_1394543261259_54013 failed
DEBUG subprocess: stderr: lxc_container: Error creating container infra_git_1394543261259_54013
```

I'm running bash 4.3-2 on the host.The base box is an Ubuntu precise.

This patch replaces the return with exits. This is probably the behaviour that was intended. :smile:
