### PR TITLE
Added dnsmasq leases file location for libvirt

### DIFF
--- a/lib/vagrant-lxc/action/fetch_ip_from_dnsmasq_leases.rb
+++ b/lib/vagrant-lxc/action/fetch_ip_from_dnsmasq_leases.rb
@@ -35,6 +35,7 @@ module Vagrant
           /var/lib/misc/dnsmasq.leases
           /var/lib/dnsmasq/dnsmasq.leases
           /var/db/dnsmasq.leases
+          /var/lib/libvirt/dnsmasq/*.leases
         )
 
         def read_dnsmasq_leases


### PR DESCRIPTION
I'm using lxc and kvm providers and standalone kvm visualization as well, so I prefer to have less virtual networks then more.
Current search path for leases files is not looking into libvirt location, this simple one line is fixing this problem.

<!---
@huboard:{"order":126.5,"custom_state":""}
-->
