### PR TITLE
Set container utsname to configured hostname per default

### DIFF
--- a/lib/vagrant-lxc/action/boot.rb
+++ b/lib/vagrant-lxc/action/boot.rb
@@ -11,7 +11,8 @@ module Vagrant
 
           config = env[:machine].provider_config
 
-          config.customize 'utsname', env[:machine].id
+          config.customize 'utsname',
+            env[:machine].config.vm.hostname || env[:machine].id
 
           env[:ui].info I18n.t("vagrant_lxc.messages.starting")
           env[:machine].provider.driver.start(config.customizations)


### PR DESCRIPTION
Previously, the utsname of a machine was set to the vagrant machine ID. As the utsname represents the hostname of the machine and is independent from the name of the actual LXC container, the hostname that was specified in the Vagrantfile should be used instead. If no hostname is provided, the machine ID will be used like before.

Additionally, this will trigger the DHCP client in the container to send the correct hostname to the DHCP server on the first request at boot. Vagrant sets the configured hostname only after the network is up. If
for example automatic DNS updates are configured, the right DNS record will be created every time.

<!---
@huboard:{"order":253.0,"custom_state":""}
-->
