### PR TITLE
Moved to Ruby >=1.9 hash syntax to improve readability

### DIFF
--- a/lib/vagrant-lxc/command/root.rb
+++ b/lib/vagrant-lxc/command/root.rb
@@ -36,7 +36,8 @@ module Vagrant
             opts.separator ""
             opts.separator "Available subcommands:"
 
-            # https://github.com/mitchellh/vagrant/commit/4194da19c60956f6e59239c0145f772be257e79d
+            # REFACTOR Use @subcommands.keys.sort  
+            #          https://github.com/mitchellh/vagrant/commit/4194da19c60956f6e59239c0145f772be257e79d
             keys = []
             @subcommands.each { |key, value| keys << key }
 

--- a/lib/vagrant-lxc/command/sudoers.rb
+++ b/lib/vagrant-lxc/command/sudoers.rb
@@ -56,26 +56,26 @@ module Vagrant
 
         def commands
          [
-           { :cmd => '/usr/bin/lxc-ls',        :args => '' },
-           { :cmd => '/usr/bin/lxc-info',      :args => '' },
-           { :cmd => '/usr/bin/lxc-attach',    :args => '' },
-           { :cmd => '/usr/bin/which',         :args => 'lxc-*' },
-           { :cmd => '/bin/cat',               :args => '/var/lib/lxc/*' },
-           { :cmd => '/bin/mkdir',             :args => '/var/lib/lxc/*' },
-           { :cmd => '/bin/su',                :args => "root -c sed -e '*' -ibak /var/lib/lxc/*" },
-           { :cmd => '/bin/su',                :args => "root -c echo '*' >> /var/lib/lxc/*" },
-           { :cmd => '/usr/bin/lxc-start',     :args => '-d --name *' },
-           { :cmd => '/bin/cp',                :args => '%{BOXES}/*/lxc/lxc-template /usr/lib/lxc/templates/*' },
-           { :cmd => '/bin/cp',                :args => '%{BOXES}/*/lxc/lxc-template /usr/share/lxc/templates/*' },
-           { :cmd => '/bin/rm',                :args => '/usr/lib/lxc/templates/*' },
-           { :cmd => '/bin/rm',                :args => '/usr/share/lxc/templates/*' },
-           { :cmd => '/bin/chmod',             :args => '+x /usr/lib/lxc/*' },
-           { :cmd => '/bin/chmod',             :args => '+x /usr/share/lxc/*' },
-           { :cmd => '/usr/bin/lxc-create',    :args => '--template * --name * -- --tarball ${BOXES}/*' },
-           { :cmd => '/bin/rm',                :args => '-rf /var/lib/lxc/*/rootfs/tmp/*' },
-           { :cmd => '/usr/bin/lxc-shutdown',  :args => '--name *' },
-           { :cmd => '/usr/bin/lxc-stop',      :args => '--name *' },
-           { :cmd => '/usr/bin/lxc-destroy',   :args => '--name *' }
+           { cmd: '/usr/bin/lxc-ls',        args: '' },
+           { cmd: '/usr/bin/lxc-info',      args: '' },
+           { cmd: '/usr/bin/lxc-attach',    args: '' },
+           { cmd: '/usr/bin/which',         args: 'lxc-*' },
+           { cmd: '/bin/cat',               args: '/var/lib/lxc/*' },
+           { cmd: '/bin/mkdir',             args: '/var/lib/lxc/*' },
+           { cmd: '/bin/su',                args: "root -c sed -e '*' -ibak /var/lib/lxc/*" },
+           { cmd: '/bin/su',                args: "root -c echo '*' >> /var/lib/lxc/*" },
+           { cmd: '/usr/bin/lxc-start',     args: '-d --name *' },
+           { cmd: '/bin/cp',                args: '%{BOXES}/*/lxc/lxc-template /usr/lib/lxc/templates/*' },
+           { cmd: '/bin/cp',                args: '%{BOXES}/*/lxc/lxc-template /usr/share/lxc/templates/*' },
+           { cmd: '/bin/rm',                args: '/usr/lib/lxc/templates/*' },
+           { cmd: '/bin/rm',                args: '/usr/share/lxc/templates/*' },
+           { cmd: '/bin/chmod',             args: '+x /usr/lib/lxc/*' },
+           { cmd: '/bin/chmod',             args: '+x /usr/share/lxc/*' },
+           { cmd: '/usr/bin/lxc-create',    args: '--template * --name * -- --tarball ${BOXES}/*' },
+           { cmd: '/bin/rm',                args: '-rf /var/lib/lxc/*/rootfs/tmp/*' },
+           { cmd: '/usr/bin/lxc-shutdown',  args: '--name *' },
+           { cmd: '/usr/bin/lxc-stop',      args: '--name *' },
+           { cmd: '/usr/bin/lxc-destroy',   args: '--name *' }
          ]
         end
       end


### PR DESCRIPTION
- Ruby >= 1.9 hash syntax
- Improved comment on Vagrant::Registry.keys
