### PR TITLE
Fix I18n error "missing interpolation argument :guestpath"

### DIFF
--- a/lib/vagrant-lxc/backports/action/share_folders.rb
+++ b/lib/vagrant-lxc/backports/action/share_folders.rb
@@ -57,7 +57,7 @@ module Vagrant
               :guestpath => data[:guestpath]
             }
             @env[:ui].info(I18n.t("vagrant.actions.vm.share_folders.mounting_entry",
-                                  :guest_path => data[:guestpath]))
+                                  :guest_path => data[:guestpath], :hostpath => data[:hostpath]))
           end
           @env[:machine].provider.driver.share_folders(folders)
         end


### PR DESCRIPTION
environment : vagrant 1.5.1 
run "vagrant up --provider=lxc" raise I18n::MissingInterpolationArgument. this cause is the lack of parameters I18n for vagrant en.yml.

so, add I18n parameter.
