### PR TITLE
Implement sorting of synced_folders

### DIFF
--- a/lib/vagrant-lxc/synced_folder.rb
+++ b/lib/vagrant-lxc/synced_folder.rb
@@ -8,6 +8,15 @@ module Vagrant
 
       def prepare(machine, folders, _opts)
         machine.ui.output(I18n.t("vagrant.actions.lxc.share_folders.preparing"))
+        # short guestpaths first, so we don't step on ourselves
+        folders = folders.sort_by do |id, data|
+          if data[:guestpath]
+            data[:guestpath].length
+          else
+            # A long enough path to just do this at the end.
+            10000
+          end
+        end
 
         folders.each do |id, data|
           host_path  = Pathname.new(File.expand_path(data[:hostpath], machine.env.root_path))


### PR DESCRIPTION
It's useful if you want to mount something inside `/vagrant` or if you have some another mount in some synced folder. I.e. old vagrant lxc could first mount `/vagrant/something`, then mount `/vagrant`, effectively hiding first mounted directory.

This piece of code is extracted from virtualbox driver. 
