### PR TITLE
Add backingstore parameters

### DIFF
--- a/lib/vagrant-lxc/action/create.rb
+++ b/lib/vagrant-lxc/action/create.rb
@@ -7,7 +7,8 @@ module Vagrant
         end
 
         def call(env)
-          container_name = env[:machine].provider_config.container_name
+          config = env[:machine].provider_config
+          container_name = config.container_name
 
           case container_name
             when :machine
@@ -24,6 +25,8 @@ module Vagrant
 
           env[:machine].provider.driver.create(
             container_name,
+            config.backingstore,
+            config.backingstore_options,
             env[:lxc_template_src],
             env[:lxc_template_config],
             env[:lxc_template_opts]

--- a/lib/vagrant-lxc/config.rb
+++ b/lib/vagrant-lxc/config.rb
@@ -6,6 +6,12 @@ module Vagrant
       # @return [Array]
       attr_reader :customizations
 
+      # A string that contains the backing store type used with lxc-create -B
+      attr_accessor :backingstore
+
+      # Optional arguments for the backing store, such as --fssize, --fstype, ...
+      attr_accessor :backingstore_options
+
       # A String that points to a file that acts as a wrapper for sudo commands.
       #
       # This allows us to have a single entry when whitelisting NOPASSWD commands
@@ -18,6 +24,8 @@ module Vagrant
 
       def initialize
         @customizations = []
+        @backingstore = UNSET_VALUE
+        @backingstore_options = []
         @sudo_wrapper   = UNSET_VALUE
         @container_name = UNSET_VALUE
       end
@@ -37,9 +45,16 @@ module Vagrant
         @customizations << [key, value]
       end
 
+      # Stores options for backingstores like lvm, btrfs, etc
+      def backingstore_option(key, value)
+        @backingstore_options << [key, value]
+      end
+
       def finalize!
         @sudo_wrapper = nil if @sudo_wrapper == UNSET_VALUE
         @container_name = nil if @container_name == UNSET_VALUE
+        @backingstore = "none" if @backingstore == UNSET_VALUE
+        @existing_container_name = nil if @existing_container_name == UNSET_VALUE
       end
 
       def validate(machine)

--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -51,12 +51,12 @@ module Vagrant
         @sudo_wrapper.run('cat', base_path.join('config').to_s)
       end
 
-      def create(name, template_path, config_file, template_options = {})
+      def create(name, backingstore, backingstore_options, template_path, config_file, template_options = {})
         @cli.name = @container_name = name
 
         import_template(template_path) do |template_name|
           @logger.debug "Creating container..."
-          @cli.create template_name, config_file, template_options
+          @cli.create template_name, backingstore, backingstore_options, config_file, template_options
         end
       end
 

--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -45,7 +45,7 @@ module Vagrant
           end
         end
 
-        def create(template, config_file, template_opts = {})
+        def create(template, backingstore, backingstore_options, config_file, template_opts = {})
           if config_file
             config_opts = ['-f', config_file]
           end
@@ -54,6 +54,8 @@ module Vagrant
           extra.unshift '--' unless extra.empty?
 
           run :create,
+              '-B', backingstore,
+              *(backingstore_options.to_a.flatten),
               '--template', template,
               '--name',     @name,
               *(config_opts),


### PR DESCRIPTION
This is mostly a patch from #235, with cloning support removed.

Also I've set `-B best` by default (the patch in #235 just crashes when no backingstore specified). Let me know if you're not comfortable with this (the lxc by default uses `-B dir`, but `best` is more sensible as it uses btrfs/zfs features if available, and fallbacks to `dir` if not). 
