### PR TITLE
Btrfs snapshot/clone

### DIFF
--- a/lib/vagrant-lxc/action/create.rb
+++ b/lib/vagrant-lxc/action/create.rb
@@ -4,6 +4,7 @@ module Vagrant
       class Create
         def initialize(app, env)
           @app = app
+          @logger = Log4r::Logger.new("vagrant::lxc::action::create")
         end
 
         def call(env)
@@ -18,19 +19,63 @@ module Vagrant
             else
               container_name = "#{env[:root_path].basename}_#{env[:machine].name}"
               container_name.gsub!(/[^-a-z0-9_]/i, "")
+              # make a copy of this variable for use in snapshot search later
+              container_name_prefix = container_name.dup
               # milliseconds + random number suffix to allow for simultaneous
               # `vagrant up` of the same box in different dirs
               container_name << "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
           end
 
-          env[:machine].provider.driver.create(
-            container_name,
-            config.backingstore,
-            config.backingstore_options,
-            env[:lxc_template_src],
-            env[:lxc_template_config],
-            env[:lxc_template_opts]
-          )
+          # Treat btrfs as follows:
+          # If a snapshot suffix is specified, search for a container name with that suffix
+          # If no snapshot is found, look for the box to make a clone. 
+          # If that is not found, setup the box to be cloned. 
+          # Create the clone based on whatever snapshot was found
+          if config.backingstore == "btrfs"
+            all_containers = env[:machine].provider.driver.all_containers
+            # Try to find a container based on a snapshot
+            if !config.snapshot_suffix.nil? && config.existing_container_name.nil?
+              snapshots_array = all_containers.select { |c|
+                c =~ /#{container_name_prefix}_([0-9_]+)_lxcsnap_#{config.snapshot_suffix}/
+              }
+              if snapshots_array.empty?
+                config.existing_container_name = nil
+              else
+                config.existing_container_name = snapshots_array.first
+                @logger.info("Using snapshot #{config.existing_container_name}")
+              end
+            end
+            # Can't find a snapshot, look for a box 
+            if all_containers.include?(env[:machine].box.name) && config.existing_container_name.nil?
+              config.existing_container_name = env[:machine].box.name
+              @logger.info("Using snapshot #{config.existing_container_name}")
+            end
+            # if the backing store is btrfs and the box doesn't exist, we setup a clonable snapshot
+            if config.existing_container_name.nil?
+              @logger.info("No snapshots found. Creating a base snapshot from #{env[:machine].box.name}.")
+              env[:machine].provider.driver.create(
+                env[:machine].box.name,
+                config.backingstore,
+                config.backingstore_options,
+                env[:lxc_template_src],
+                env[:lxc_template_config],
+                env[:lxc_template_opts]
+              )
+              config.existing_container_name = env[:machine].box.name
+            end
+            # Create the clone based off of whatever container we found
+            @logger.debug("Making a clone from #{config.existing_container_name} to #{container_name}")
+            env[:machine].provider.driver.clone(config.existing_container_name, container_name)
+          else
+            env[:machine].provider.driver.create(
+              container_name,
+              config.backingstore,
+              config.backingstore_options,
+              env[:lxc_template_src],
+              env[:lxc_template_config],
+              env[:lxc_template_opts]
+            )
+          end
 
           env[:machine].id = container_name
 

--- a/lib/vagrant-lxc/action/create.rb
+++ b/lib/vagrant-lxc/action/create.rb
@@ -19,7 +19,6 @@ module Vagrant
             else
               container_name = "#{env[:root_path].basename}_#{env[:machine].name}"
               container_name.gsub!(/[^-a-z0-9_]/i, "")
-              # make a copy of this variable for use in snapshot search later
               # milliseconds + random number suffix to allow for simultaneous
               # `vagrant up` of the same box in different dirs
               container_name << "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
@@ -35,7 +34,8 @@ module Vagrant
             # Try to find a container based on a snapshot
             if !config.snapshot_suffix.nil? && config.existing_container_name.nil?
               snapshots_array = all_containers.select { |c|
-                c =~ /#{env[:machine].name}_([0-9_]+)_lxcsnap_#{config.snapshot_suffix}/
+                #c =~ /#{env[:machine].name}_([0-9_]+)_lxcsnap_#{config.snapshot_suffix}/
+                c =~ /^s_#{env[:machine].name}_#{config.snapshot_suffix}/
               }
               if snapshots_array.empty?
                 config.existing_container_name = nil

--- a/lib/vagrant-lxc/action/create.rb
+++ b/lib/vagrant-lxc/action/create.rb
@@ -20,7 +20,6 @@ module Vagrant
               container_name = "#{env[:root_path].basename}_#{env[:machine].name}"
               container_name.gsub!(/[^-a-z0-9_]/i, "")
               # make a copy of this variable for use in snapshot search later
-              container_name_prefix = container_name.dup
               # milliseconds + random number suffix to allow for simultaneous
               # `vagrant up` of the same box in different dirs
               container_name << "_#{(Time.now.to_f * 1000.0).to_i}_#{rand(100000)}"
@@ -36,7 +35,7 @@ module Vagrant
             # Try to find a container based on a snapshot
             if !config.snapshot_suffix.nil? && config.existing_container_name.nil?
               snapshots_array = all_containers.select { |c|
-                c =~ /#{container_name_prefix}_([0-9_]+)_lxcsnap_#{config.snapshot_suffix}/
+                c =~ /#{env[:machine].name}_([0-9_]+)_lxcsnap_#{config.snapshot_suffix}/
               }
               if snapshots_array.empty?
                 config.existing_container_name = nil

--- a/lib/vagrant-lxc/command/root.rb
+++ b/lib/vagrant-lxc/command/root.rb
@@ -13,6 +13,10 @@ module Vagrant
               require_relative 'sudoers'
               Sudoers
             end
+            registry.register(:snapshot) do
+              require_relative 'snapshot'
+              Snapshot
+            end
           end
           super(argv, env)
         end

--- a/lib/vagrant-lxc/command/snapshot.rb
+++ b/lib/vagrant-lxc/command/snapshot.rb
@@ -13,7 +13,7 @@ module Vagrant
         end
 
         def execute
-          options = { user: ENV['USER'], snapshot_suffix: "" }
+          options = { user: ENV['USER'], snapshot_suffix: "", snapshot_list: false }
 
           opts = OptionParser.new do |opts|
             opts.banner = "Usage: vagrant lxc -s snapshot_suffix. Note that this will halt all the containers."
@@ -21,21 +21,47 @@ module Vagrant
             opts.on('-s snapshot_suffix', '--snapshot_suffix snapshot', String, "The snapshot suffix.") do |o|
               options[:snapshot_suffix] = o
             end
+            opts.on('-l', '--list', String, "List snapshots") do |o|
+              options[:snapshot_list] = true
+            end
           end
 
           argv = parse_options(opts)
-          return unless argv 
+          return unless argv
+
+          if options[:snapshot_list]
+            list_snapshots
+            return
+          end
+
           if options[:snapshot_suffix].empty?
             raise Vagrant::Errors::CLIInvalidUsage,
               help: opts.help.chomp
+          else
+            create_snapshot(options[:snapshot_suffix])
           end
 
+        end
+
+        def list_snapshots
+          with_target_vms(argv) do |machine|
+            snapshot_list=machine.provider.driver.all_containers.grep(/lxcsnap/)
+            snapshot_names = []
+            snapshot_list.each do |m|
+              snapshot_names << m.match(/_lxcsnap_(.*)/)[1]
+            end
+            snapshot_names.uniq!
+            puts snapshot_names
+          end
+        end
+
+        def create_snapshot(snapshot_suffix)
           with_target_vms(argv) do |machine|
             machine.action(:halt, :force_halt => true)
             container_name=machine.provider.driver.container_name.to_s
-            snapshot_name = container_name + "_lxcsnap_" + options[:snapshot_suffix]
+            snapshot_name = container_name + "_lxcsnap_" + snapshot_suffix
             if machine.provider.driver.all_containers.include?(snapshot_name)
-              raise Vagrant::Errors::SnapshotAlreadyExists, name: @name
+              raise Vagrant::Errors::SnapshotAlreadyExists, name: snapshot_name
             end
             machine.provider.driver.clone(container_name, snapshot_name)
           end

--- a/lib/vagrant-lxc/command/snapshot.rb
+++ b/lib/vagrant-lxc/command/snapshot.rb
@@ -37,7 +37,7 @@ module Vagrant
             if machine.provider.driver.all_containers.include?(snapshot_name)
               raise Vagrant::Errors::SnapshotAlreadyExists, name: @name
             end
-            machine.provider.driver.clone(tmp_name, snapshot_name)
+            machine.provider.driver.clone(container_name, snapshot_name)
           end
         end
       end

--- a/lib/vagrant-lxc/command/snapshot.rb
+++ b/lib/vagrant-lxc/command/snapshot.rb
@@ -52,6 +52,7 @@ module Vagrant
             end
             snapshot_names.uniq!
             puts snapshot_names
+            break
           end
         end
 

--- a/lib/vagrant-lxc/command/snapshot.rb
+++ b/lib/vagrant-lxc/command/snapshot.rb
@@ -44,7 +44,7 @@ module Vagrant
         end
 
         def list_snapshots
-          with_target_vms(argv) do |machine|
+          with_target_vms do |machine|
             snapshot_list=machine.provider.driver.all_containers.grep(/lxcsnap/)
             snapshot_names = []
             snapshot_list.each do |m|
@@ -56,7 +56,7 @@ module Vagrant
         end
 
         def create_snapshot(snapshot_suffix)
-          with_target_vms(argv) do |machine|
+          with_target_vms do |machine|
             machine.action(:halt, :force_halt => true)
             container_name=machine.provider.driver.container_name.to_s
             snapshot_name = container_name + "_lxcsnap_" + snapshot_suffix

--- a/lib/vagrant-lxc/command/snapshot.rb
+++ b/lib/vagrant-lxc/command/snapshot.rb
@@ -1,0 +1,46 @@
+require 'tempfile'
+require "vagrant-lxc/provider"
+
+module Vagrant
+  module LXC
+    module Command
+      class Snapshot < Vagrant.plugin("2", :command)
+
+        def initialize(argv, env)
+          super
+          @argv
+          @env = env
+        end
+
+        def execute
+          options = { user: ENV['USER'], snapshot_suffix: "" }
+
+          opts = OptionParser.new do |opts|
+            opts.banner = "Usage: vagrant lxc -s snapshot_suffix. Note that this will halt all the containers."
+            opts.separator ""
+            opts.on('-s snapshot_suffix', '--snapshot_suffix snapshot', String, "The snapshot suffix.") do |o|
+              options[:snapshot_suffix] = o
+            end
+          end
+
+          argv = parse_options(opts)
+          return unless argv 
+          if options[:snapshot_suffix].empty?
+            raise Vagrant::Errors::CLIInvalidUsage,
+              help: opts.help.chomp
+          end
+
+          with_target_vms(argv) do |machine|
+            machine.action(:halt, :force_halt => true)
+            container_name=machine.provider.driver.container_name.to_s
+            snapshot_name = container_name + "_lxcsnap_" + options[:snapshot_suffix]
+            if machine.provider.driver.all_containers.include?(snapshot_name)
+              raise Vagrant::Errors::SnapshotAlreadyExists, name: @name
+            end
+            machine.provider.driver.clone(tmp_name, snapshot_name)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/vagrant-lxc/config.rb
+++ b/lib/vagrant-lxc/config.rb
@@ -18,12 +18,18 @@ module Vagrant
       # machine name, set this to :machine
       attr_accessor :container_name
 
+      attr_accessor :existing_container_name
+
+      # A string that contains the suffix of the snapshot to load
+      attr_accessor :snapshot_suffix
+
       def initialize
         @customizations = []
         @backingstore = UNSET_VALUE
         @backingstore_options = []
         @sudo_wrapper   = UNSET_VALUE
         @container_name = UNSET_VALUE
+        @snapshot_suffix = UNSET_VALUE
       end
 
       # Customize the container by calling `lxc-start` with the given
@@ -51,6 +57,7 @@ module Vagrant
         @container_name = nil if @container_name == UNSET_VALUE
         @backingstore = "best" if @backingstore == UNSET_VALUE
         @existing_container_name = nil if @existing_container_name == UNSET_VALUE
+        @snapshot_suffix = nil if @snapshot_suffix == UNSET_VALUE
       end
     end
   end

--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -55,6 +55,12 @@ module Vagrant
         @sudo_wrapper.run('cat', base_path.join('config').to_s)
       end
 
+      def clone(existing_container_name, name)
+      	@cli.name = @container_name = name
+	@logger.debug "Cloning container..."
+	@cli.clone(existing_container_name, name)
+      end
+
       def create(name, backingstore, backingstore_options, template_path, config_file, template_options = {})
         @cli.name = @container_name = name
 

--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -45,6 +45,13 @@ module Vagrant
           end
         end
 
+	def clone(existing_container_name, name)
+	  run :clone,
+	      '-s',
+	      '-o', existing_container_name,
+	      '-n', name
+        end
+
         def create(template, backingstore, backingstore_options, config_file, template_opts = {})
           if config_file
             config_opts = ['-f', config_file]

--- a/lib/vagrant-lxc/errors.rb
+++ b/lib/vagrant-lxc/errors.rb
@@ -26,6 +26,10 @@ module Vagrant
         error_key(:lxc_container_already_exists)
       end
 
+      class SnapshotAlreadyExists < Vagrant::Errors::VagrantError
+        error_key(:lxc_container_already_exists)
+      end
+
       # Box related errors
       class TemplateFileMissing < Vagrant::Errors::VagrantError
         error_key(:lxc_template_file_missing)


### PR DESCRIPTION
"vagrant lxc snapshot -s test" will create snapshots of all machines in the current directory in the form "s_machine1_test", "s_machine2_test". 

To create a machine based off this snapshot, the snapshot_suffix variable needs to be set and it will search for the snapshot when doing a "vagrant up"

From the code comments on the btrfs creation logic:
-          # Treat btrfs as follows:
-          # If a snapshot suffix is specified, search for a container name with that suffix
-          # If no snapshot is found, look for the box to make a clone. 
-          # If that is not found, setup the box to be cloned. 
-          # Create the clone based on whatever snapshot was found
