### PR TITLE
uninitialized constant Tempfile

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -6,6 +6,8 @@ require "vagrant-lxc/driver/cli"
 
 require "etc"
 
+require "tempfile"
+
 module Vagrant
   module LXC
     class Driver


### PR DESCRIPTION
I had an error when running vagrant up --provider=lxc
uninitialized constant Tempfile

adding the require like in another file, fixed the problem for me

I'm on vagrant 1.4.3 with ruby 2.0
