### PR TITLE
Support for formatted overlayfs path spec when finding the root FS path

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -45,7 +45,21 @@ module Vagrant
       end
 
       def rootfs_path
-        Pathname.new(config_string.match(/^lxc\.rootfs\s+=\s+(.+)$/)[1])
+        config_entry = config_string.match(/^lxc\.rootfs\s+=\s+(.+)$/)[1]
+        case config_entry
+        when /^overlayfs:/
+          # Split on colon (:), ignoring any colon escaped by an escape character ( \ )
+          # Pays attention to when the escape character is itself escaped.
+          fs_type, master_path, overlay_path = config_entry.split(/(?<!\\)(?:\\\\)*:/)
+          if overlay_path
+            Pathname.new(overlay_path)
+          else
+            # Malformed: fall back to prior behaviour
+            Pathname.new(config_entry)
+          end
+        else
+          Pathname.new(config_entry)
+        end
       end
 
       def mac_address


### PR DESCRIPTION
We're using snapshots in a CI set-up so that a Vagrant cluster can be built
once, then each push to the repository only checked as an incremental
update to the cluster. We copy each LXC VM to a master image, then re-create
the original names as snapshots.

This change corrects a method which assumes the LXC root path in the config
file is a simple directory name, which is only true for directory-backed
instances.

Also, back-port to 0.8 series will be PRed.