### PR TITLE
Support for formatted overlayfs path spec when finding the root FS path

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -70,19 +70,28 @@ module Vagrant
         end
       end
 
+      def share_folder(host_path, guest_path, mount_options = nil)
+        guest_path      = guest_path.gsub(/^\//, '')
+        guest_full_path = rootfs_path.join(guest_path)
+
+        unless guest_full_path.directory?
+          begin
+            @logger.debug("Guest path doesn't exist, creating: #{guest_full_path}")
+            @sudo_wrapper.run('mkdir', '-p', guest_full_path.to_s)
+          rescue Errno::EACCES
+            raise Vagrant::Errors::SharedFolderCreateFailed, :path => guest_path.to_s
+          end
+        end
+
+        mount_options = Array(mount_options || ['bind'])
+        host_path     = host_path.to_s.gsub(' ', '\\\040')
+        guest_path    = guest_path.gsub(' ', '\\\040')
+        @customizations << ['mount.entry', "#{host_path} #{guest_path} none #{mount_options.join(',')} 0 0"]
+      end
+
       def share_folders(folders)
         folders.each do |folder|
-          guestpath = rootfs_path.join(folder[:guestpath].gsub(/^\//, ''))
-          unless guestpath.directory?
-            begin
-              @logger.debug("Guest path doesn't exist, creating: #{guestpath}")
-              @sudo_wrapper.run('mkdir', '-p', guestpath.to_s)
-            rescue Errno::EACCES
-              raise Vagrant::Errors::SharedFolderCreateFailed, :path => guestpath.to_s
-            end
-          end
-
-          @customizations << ['mount.entry', "#{folder[:hostpath]} #{guestpath} none bind 0 0"]
+          share_folder(folder[:hostpath], folder[:guestpath], folder[:mountoptions] || nil)
         end
       end
 

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -143,6 +143,7 @@ describe Vagrant::LXC::Driver do
     
     let(:shared_folder)       { {guestpath: '/vagrant', hostpath: '/path/to/host/dir'} }
     let(:folders)             { [shared_folder] }
+    let(:expected_mount_path) { "vagrant" }
     let(:expected_guest_path) { "#{rootfs_path}/vagrant" }
     let(:sudo_wrapper)        { instance_double('Vagrant::LXC::SudoWrapper', run: true) }
 
@@ -161,7 +162,7 @@ describe Vagrant::LXC::Driver do
       it 'adds a mount.entry to its local customizations' do
         subject.customizations.should include [
           'mount.entry',
-          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind 0 0"
+          "#{shared_folder[:hostpath]} #{expected_mount_path} none bind 0 0"
         ]
       end
     end
@@ -189,7 +190,7 @@ describe Vagrant::LXC::Driver do
       it 'adds a mount.entry to its local customizations' do
         subject.customizations.should include [
           'mount.entry',
-          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind 0 0"
+          "#{shared_folder[:hostpath]} #{expected_mount_path} none bind 0 0"
         ]
       end
     end
@@ -217,7 +218,7 @@ describe Vagrant::LXC::Driver do
       it 'adds a mount.entry to its local customizations' do
         subject.customizations.should include [
           'mount.entry',
-          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind 0 0"
+          "#{shared_folder[:hostpath]} #{expected_mount_path} none bind 0 0"
         ]
       end
     end


### PR DESCRIPTION
Back-ported update to support booting over overlay-fs LXC images.

We're using snapshots in a CI set-up so that a Vagrant cluster can be built
once, then each push to the repository only checked as an incremental
update to the cluster. We copy each LXC VM to a master image, then re-create
the original names as snapshots.

This change corrects a method which assumes the LXC root path in the config
file is a simple directory name, which is only true for directory-backed
instances.
