### PR TITLE
Support private networking using DHCP

### DIFF
--- a/lib/vagrant-lxc/action/private_networks.rb
+++ b/lib/vagrant-lxc/action/private_networks.rb
@@ -26,16 +26,19 @@ module Vagrant
             next if type.to_sym != :private_network
 
             container_name = env[:machine].provider.driver.container_name
+            address_type   = config[:type]
             ip             = config[:ip]
             bridge_ip      = config.fetch(:lxc__bridge_ip) { build_bridge_ip(ip) }
             bridge         = config.fetch(:lxc__bridge_name)
 
-            env[:machine].provider.driver.configure_private_network(bridge, bridge_ip, container_name, ip)
+            env[:machine].provider.driver.configure_private_network(bridge, bridge_ip, container_name, address_type, ip)
           end
         end
 
         def build_bridge_ip(ip)
-          ip.sub(/^(\d+\.\d+\.\d+)\.\d+/, '\1.254')
+          if ip
+            ip.sub(/^(\d+\.\d+\.\d+)\.\d+/, '\1.254')
+          end
         end
       end
     end

--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -140,17 +140,16 @@ module Vagrant
         @cli.attach(*command)
       end
 
-      def configure_private_network(bridge_name, bridge_ip, container_name, ip)
+      def configure_private_network(bridge_name, bridge_ip, container_name, address_type, ip)
         @logger.info "Configuring network interface for #{container_name} using #{ip} and bridge #{bridge_name}"
-        cmd = [
-          Vagrant::LXC.source_root.join('scripts/pipework').to_s,
-          bridge_name,
-          container_name,
-          "#{ip}/24"
-        ]
-        @sudo_wrapper.run(*cmd)
+        if ip
+          ip += '/24'
+        end
 
         if ! bridge_has_an_ip?(bridge_name)
+          if not bridge_ip
+            raise "Bridge has no IP and none was specified!"
+          end
           @logger.info "Adding #{bridge_ip} to the bridge #{bridge_name}"
           cmd = [
             'ip',
@@ -162,6 +161,14 @@ module Vagrant
           ]
           @sudo_wrapper.run(*cmd)
         end
+
+        cmd = [
+          Vagrant::LXC.source_root.join('scripts/pipework').to_s,
+          bridge_name,
+          container_name,
+          ip ||= "dhcp"
+        ]
+        @sudo_wrapper.run(*cmd)
       end
 
       def bridge_has_an_ip?(bridge_name)


### PR DESCRIPTION
Added a type option similar to the way vagrant core does this: http://docs.vagrantup.com/v2/networking/private_network.html. This patch currently depends on a pre-existing dhcp server listening on the bridged network (this was the case after installing the lxc package on Ubuntu). The type option isn't strictly necessary as-is, but would be useful if you want to support starting a dhcp server as needed.