### PR TITLE
vagrant-lxc-wrapper: Use correct ruby interpreter

### DIFF
--- a/lib/vagrant-lxc/command/sudoers.rb
+++ b/lib/vagrant-lxc/command/sudoers.rb
@@ -83,6 +83,7 @@ module Vagrant
               hash[cmd] = `which #{cmd}`.strip
             end
             hash['lxc_bin'] = Pathname(`which lxc-create`.strip).parent.to_s
+            hash['ruby'] = Gem.ruby
           end
         end
       end

--- a/templates/sudoers.rb.erb
+++ b/templates/sudoers.rb.erb
@@ -1,4 +1,4 @@
-#!/opt/vagrant/embedded/bin/ruby
+#!<%= cmd_paths['ruby'] %>
 # Automatically created by vagrant-lxc
 
 class Whitelist


### PR DESCRIPTION
Previously, we hardcoded to using the ruby binary in /opt/vagrant[..].
On some systems, this path is incorrect, so instead we use the
path of the interpreter that is executing the `vagrant lxc sudoers`
command.