### PR TITLE
move mountpoint creation to lxc template for lvm rootfs support

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -87,26 +87,14 @@ module Vagrant
 
       def share_folders(folders)
         folders.each do |f|
-          share_folder(f[:hostpath], f[:guestpath], f.fetch(:mount_options, 'bind'))
+          share_folder(f[:hostpath], f[:guestpath], f.fetch(:mount_options, nil))
         end
       end
 
       def share_folder(host_path, guest_path, mount_options = nil)
-        guest_path      = guest_path.gsub(/^\//, '')
-        guest_full_path = rootfs_path.join(guest_path)
-
-        unless guest_full_path.directory?
-          begin
-            @logger.debug("Guest path doesn't exist, creating: #{guest_full_path}")
-            @sudo_wrapper.run('mkdir', '-p', guest_full_path.to_s)
-          rescue Errno::EACCES
-            raise Vagrant::Errors::SharedFolderCreateFailed, :path => guest_path.to_s
-          end
-        end
-
-        mount_options = Array(mount_options || ['bind'])
+        guest_path      = guest_path.gsub(/^\//, '').gsub(' ', '\\\040')
+        mount_options = Array(mount_options || ['bind', 'create=dir'])
         host_path     = host_path.to_s.gsub(' ', '\\\040')
-        guest_path    = guest_path.gsub(' ', '\\\040')
         @customizations << ['mount.entry', "#{host_path} #{guest_path} none #{mount_options.join(',')} 0 0"]
       end
 

--- a/spec/unit/driver_spec.rb
+++ b/spec/unit/driver_spec.rb
@@ -192,14 +192,10 @@ describe Vagrant::LXC::Driver do
         subject.share_folders(folders)
       end
 
-      it "creates guest folder under container's rootfs" do
-        expect(sudo_wrapper).to have_received(:run).with("mkdir", "-p", "#{rootfs_path}/#{expected_guest_path}")
-      end
-
       it 'adds a mount.entry to its local customizations' do
         expect(subject.customizations).to include [
           'mount.entry',
-          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind 0 0"
+          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind,create=dir 0 0"
         ]
       end
 
@@ -213,7 +209,7 @@ describe Vagrant::LXC::Driver do
       it 'supports directories with spaces' do
         expect(subject.customizations).to include [
           'mount.entry',
-          "/path/with\\040space tmp/with\\040space none bind 0 0"
+          "/path/with\\040space tmp/with\\040space none bind,create=dir 0 0"
         ]
       end
     end
@@ -243,7 +239,7 @@ describe Vagrant::LXC::Driver do
       it 'adds a mount.entry to its local customizations' do
         expect(subject.customizations).to include [
           'mount.entry',
-          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind 0 0"
+          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind,create=dir 0 0"
         ]
       end
     end
@@ -273,7 +269,7 @@ describe Vagrant::LXC::Driver do
       it 'adds a mount.entry to its local customizations' do
         expect(subject.customizations).to include [
           'mount.entry',
-          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind 0 0"
+          "#{shared_folder[:hostpath]} #{expected_guest_path} none bind,create=dir 0 0"
         ]
       end
     end


### PR DESCRIPTION
Fixes #359 where shared folders break `vagrant up` with LVM.