### PR TITLE
Create networking bridge if it is missing

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -162,7 +162,7 @@ module Vagrant
             bridge_name
           ]
           @sudo_wrapper.run(*cmd)
-          @sudo_wrapper.run('ifconfig', bridge_name, 'up')
+          @sudo_wrapper.run('ip', 'link', 'set', bridge_name, 'up')
         end
 
         cmd = [
@@ -181,7 +181,7 @@ module Vagrant
 
       def bridge_exists?(bridge_name)
         @logger.info "Checking whether bridge #{bridge_name} exists"
-        brctl_output = `ifconfig -a | grep -q #{bridge_name}`
+        brctl_output = `ip link | grep -q #{bridge_name}`
         $?.to_i == 0
       end
 
@@ -196,7 +196,7 @@ module Vagrant
         return unless bridge_exists?(bridge_name)
 
         @logger.info "Removing bridge #{bridge_name}"
-        @sudo_wrapper.run('ifconfig', bridge_name, 'down')
+        @sudo_wrapper.run('ip', 'link', 'set', bridge_name, 'down')
         @sudo_wrapper.run('brctl', 'delbr', bridge_name)
       end
 

--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -181,7 +181,7 @@ module Vagrant
 
       def bridge_exists?(bridge_name)
         @logger.info "Checking whether bridge #{bridge_name} exists"
-        brctl_output = `ip link | grep -q #{bridge_name}`
+        brctl_output = `ip link | egrep -q " #{bridge_name}:"`
         $?.to_i == 0
       end
 

--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -134,6 +134,20 @@ module Vagrant
           ip += '/24'
         end
 
+        if ! bridge_exists?(bridge_name)
+          if not bridge_ip
+            raise "Bridge is missing and no IP was specified!"
+          end
+
+          @logger.info "Creating the bridge #{bridge_name}"
+          cmd = [
+            'brctl',
+            'addbr',
+            bridge_name
+          ]
+          @sudo_wrapper.run(*cmd)
+        end
+
         if ! bridge_has_an_ip?(bridge_name)
           if not bridge_ip
             raise "Bridge has no IP and none was specified!"
@@ -148,6 +162,7 @@ module Vagrant
             bridge_name
           ]
           @sudo_wrapper.run(*cmd)
+          @sudo_wrapper.run('ifconfig', bridge_name, 'up')
         end
 
         cmd = [

--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -164,6 +164,12 @@ module Vagrant
         `ip -4 addr show scope global #{bridge_name}` =~ /^\s+inet ([0-9.]+)\/[0-9]+\s+/
       end
 
+      def bridge_exists?(bridge_name)
+        @logger.info "Checking whether bridge #{bridge_name} exists"
+        brctl_output = `ifconfig -a | grep -q #{bridge_name}`
+        $?.to_i == 0
+      end
+
       def bridge_is_in_use?(bridge_name)
         # REFACTOR: This method is **VERY** hacky
         @logger.info "Checking if bridge #{bridge_name} is in use"
@@ -172,9 +178,7 @@ module Vagrant
       end
 
       def remove_bridge(bridge_name)
-        @logger.info "Checking whether bridge #{bridge_name} exists"
-        brctl_output = `ifconfig -a | grep -q #{bridge_name}`
-        return if $?.to_i != 0
+        return unless bridge_exists?(bridge_name)
 
         @logger.info "Removing bridge #{bridge_name}"
         @sudo_wrapper.run('ifconfig', bridge_name, 'down')

--- a/templates/sudoers.rb.erb
+++ b/templates/sudoers.rb.erb
@@ -106,7 +106,7 @@ Whitelist.add '<%= cmd_paths['tar'] %>', '--numeric-owner', '-cvzf', %r{/tmp/.*/
 Whitelist.add '<%= cmd_paths['chown'] %>', /\A\d+:\d+\z/, %r{\A/tmp/.*/rootfs\.tar\.gz\z}
 # - Private network script and commands
 Whitelist.add '<%= cmd_paths['ip'] %>', 'addr', 'add', /(\d+|\.)+\/24/, 'dev', /.+/
-Whitelist.add '<%= cmd_paths['ifconfig'] %>', /.+/, /(up|down)/
+Whitelist.add '<%= cmd_paths['ip'] %>', 'link', 'set', /.+/, /(up|down)/
 Whitelist.add '<%= cmd_paths['brctl'] %>', /(addbr|delbr)/, /.+/
 Whitelist.add_regex %r{<%= pipework_regex %>}, '**'
 

--- a/templates/sudoers.rb.erb
+++ b/templates/sudoers.rb.erb
@@ -106,8 +106,8 @@ Whitelist.add '<%= cmd_paths['tar'] %>', '--numeric-owner', '-cvzf', %r{/tmp/.*/
 Whitelist.add '<%= cmd_paths['chown'] %>', /\A\d+:\d+\z/, %r{\A/tmp/.*/rootfs\.tar\.gz\z}
 # - Private network script and commands
 Whitelist.add '<%= cmd_paths['ip'] %>', 'addr', 'add', /(\d+|\.)+\/24/, 'dev', /.+/
-Whitelist.add '<%= cmd_paths['ifconfig'] %>', /.+/, 'down'
-Whitelist.add '<%= cmd_paths['brctl'] %>', 'delbr', /.+/
+Whitelist.add '<%= cmd_paths['ifconfig'] %>', /.+/, /(up|down)/
+Whitelist.add '<%= cmd_paths['brctl'] %>', /(addbr|delbr)/, /.+/
 Whitelist.add_regex %r{<%= pipework_regex %>}, '**'
 
 ##


### PR DESCRIPTION
Currently, a bridge device of an existing bridge must be specified for private networking support.
Create that bridge automatically if needed.