### PR TITLE
forward_ports: bind to localhost only by default

### DIFF
--- a/lib/vagrant-lxc/action/forward_ports.rb
+++ b/lib/vagrant-lxc/action/forward_ports.rb
@@ -67,7 +67,9 @@ module Vagrant
 
             # TODO: Deprecate this behavior of "automagically" skipping ssh forwarded ports
             if type == :forwarded_port && options[:id] != 'ssh'
-              options.delete(:host_ip) if options.fetch(:host_ip, '').to_s.strip.empty?
+              if options.fetch(:host_ip, '').to_s.strip.empty?
+                options[:host_ip] = '127.0.0.1'
+              end
               mappings[options[:host]] = options
             end
           end

--- a/spec/unit/action/forward_ports_spec.rb
+++ b/spec/unit/action/forward_ports_spec.rb
@@ -38,21 +38,21 @@ describe Vagrant::LXC::Action::ForwardPorts do
     )
   end
 
-  it 'skips --laddr parameter if host_ip is nil' do
+  it 'Uses 127.0.0.1 as default if host_ip is nil' do
     forward_conf.delete(:host_ip)
     subject.stub(system: true)
     subject.call(env)
     expect(subject).to have_received(:spawn).with(
-      "redir --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+      "redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
     )
   end
 
-  it 'skips --laddr parameter if host_ip is a blank string' do
+  it 'Uses 127.0.0.1 by default if host_ip is a blank string' do
     forward_conf[:host_ip] = ' '
     subject.stub(system: true)
     subject.call(env)
     expect(subject).to have_received(:spawn).with(
-      "redir --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+      "redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
     )
   end
 
@@ -86,21 +86,21 @@ describe Vagrant::LXC::Action::ForwardPorts do
       )
     end
 
-    it 'skips --laddr parameter if host_ip is nil' do
+    it 'Uses 127.0.0.1 by default if host_ip is nil' do
       forward_conf.delete(:host_ip)
       subject.stub(system: true)
       subject.call(env)
       expect(subject).to have_received(:spawn).with(
-        "sudo redir --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+        "sudo redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
       )
     end
 
-    it 'skips --laddr parameter if host_ip is a blank string' do
+    it 'Uses 127.0.0.1 by default if host_ip is a blank string' do
       forward_conf[:host_ip] = ' '
       subject.stub(system: true)
       subject.call(env)
       expect(subject).to have_received(:spawn).with(
-        "sudo redir --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
+        "sudo redir --laddr=127.0.0.1 --lport=#{host_port} --caddr=#{container_ip} --cport=#{guest_port} 2>/dev/null"
       )
     end
   end


### PR DESCRIPTION
This has been raised as security concern on vagrant itself, and fixed
there some time ago.