### PR TITLE
Fix base lxc path in /usr/local/bin/vagrant-lxc-wrapper.

### DIFF
--- a/templates/sudoers.rb.erb
+++ b/templates/sudoers.rb.erb
@@ -78,7 +78,12 @@ class Whitelist
   end
 end
 
-base = "/var/lib/lxc"
+base = if File.exists?('<%= cmd_paths['lxc_bin'] %>/lxc-config')
+  `<%= cmd_paths['lxc_bin'] %>/lxc-config lxc.lxcpath`.chomp
+else
+  '/var/lib/lxc'
+end
+
 base_path = %r{\A#{base}/.*\z}
 
 ##


### PR DESCRIPTION
If lxc.lxcpath set to custom path (not default /var/lib/lxc) then all the commands are considered invalid.
