### PR TITLE
ignore informational lxc-stop return code

### DIFF
--- a/lib/vagrant-lxc/driver/cli.rb
+++ b/lib/vagrant-lxc/driver/cli.rb
@@ -85,9 +85,20 @@ module Vagrant
           run :start, '-d', '--name', @name, *Array(options)
         end
 
+        ## lxc-stop will exit 2 if machine was already stopped
+        # Man Page: 
+        # 2      The specified container exists but was not running.
         def stop
           attach '/sbin/halt' if supports_attach?
-          run :stop, '--name', @name
+          begin
+            run :stop, '--name', @name
+          rescue LXC::Errors::ExecuteError => e
+            if e.exitcode == 2
+               @logger.info "Machine already stopped, lxc-stop returned 2"
+            else
+		raise e
+            end 
+          end
         end
 
         def attach(*cmd)

--- a/lib/vagrant-lxc/errors.rb
+++ b/lib/vagrant-lxc/errors.rb
@@ -5,12 +5,13 @@ module Vagrant
     module Errors
       class ExecuteError < Vagrant::Errors::VagrantError
         error_key(:lxc_execute_error)
-        attr_reader :stderr, :stdout
+        attr_reader :stderr, :stdout, :exitcode
         def initialize(message, *args)
           super
           if message.is_a?(Hash)
             @stderr = message[:stderr]
             @stdout = message[:stdout]
+            @exitcode = message[:exitcode]
           end
         end
       end

--- a/lib/vagrant-lxc/sudo_wrapper.rb
+++ b/lib/vagrant-lxc/sudo_wrapper.rb
@@ -49,7 +49,7 @@ module Vagrant
               @logger.info("Exit code != 0, but interrupted. Ignoring.")
             else
               raise LXC::Errors::ExecuteError,
-                command: command.inspect, stderr: r.stderr, stdout: r.stdout
+                command: command.inspect, stderr: r.stderr, stdout: r.stdout, exitcode: r.exit_code
             end
           end
         end


### PR DESCRIPTION
If the user executes "vagrant destroy", a graceful shutdown of the LXC container is performed.

This leads to: 

```
 INFO subprocess: Starting process: ["/usr/bin/sudo", "/usr/bin/env", "lxc-attach", "--name", "jenkins.vagrant.local", "--", "/bin/true"]
....
 INFO subprocess: Starting process: ["/usr/bin/sudo", "/usr/bin/env", "lxc-attach", "--name", "jenkins.vagrant.local", "--", "/sbin/halt"]
...
 INFO subprocess: Starting process: ["/usr/bin/sudo", "/usr/bin/env", "lxc-stop", "--name", "jenkins.vagrant.local"]
  INFO subprocess: Command not in installer, restoring original environment...
DEBUG subprocess: Selecting on IO
DEBUG subprocess: stderr: jenkins.vagrant.local is not running
DEBUG subprocess: Waiting for process to exit. Remaining to timeout: 32000
DEBUG subprocess: Exit status: 2
ERROR warden: Error occurred: There was an error executing ["sudo", "/usr/bin/env", "lxc-stop", "--name", "jenkins.vagrant.local"]
```

The man page states: 

```
EXIT VALUE
       0      The container was successfully stopped.

       1      An error occurred while stopping the container.

       2      The specified container exists but was not running.
```
There is a shutdown race here: if the container halts before lxc-stop is called, it returns 2.