### PR TITLE
Preserve xattrs in container rootfs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ to see it in action.
 
 * [Vagrant 1.5+](http://www.vagrantup.com/downloads.html) (tested with 1.7.2)
 * lxc 0.7.5+
+* tar 1.27 (the lxc-template script uses the --xattrs option)
 * `redir` (if you are planning to use port forwarding)
 * `brctl` (if you are planning to use private networks, on Ubuntu this means `apt-get install bridge-utils`)
 * A [kernel != 3.5.0-17.28](https://github.com/fgrehm/vagrant-lxc/wiki/Troubleshooting#wiki-im-unable-to-restart-containers)

--- a/scripts/lxc-template
+++ b/scripts/lxc-template
@@ -124,7 +124,7 @@ mkdir -p /var/lock/subsys
     fi
 
     mkdir -p ${LXC_ROOTFS}
-    (cd ${LXC_ROOTFS} && tar xfz ${LXC_TARBALL} --strip-components=${LXC_STRIP_COMPONENTS})
+    (cd ${LXC_ROOTFS} && tar xfz ${LXC_TARBALL} --strip-components=${LXC_STRIP_COMPONENTS} --xattrs --xattrs-include=*)
     if [ $? -ne 0 ]; then
         echo "Failed to extract rootfs"
         exit 1


### PR DESCRIPTION
Tar 1.27 and up supports xattrs, but does not enable them by default. Extracting files without xattrs strips them of POSIX Capabilities (ex: ping on certain distros). https://www.cyphar.com/blog/post/docker-broken-ping