### PR TITLE
Load locale file only once

### DIFF
--- a/lib/vagrant-lxc/plugin.rb
+++ b/lib/vagrant-lxc/plugin.rb
@@ -8,27 +8,22 @@ module Vagrant
       The LXC provider allows Vagrant to manage and control
       LXC-based virtual machines.
       EOF
-      locale_loaded = false
 
       provider(:lxc, parallel: true, priority: 7) do
         require File.expand_path("../provider", __FILE__)
-
-        if not locale_loaded
-            I18n.load_path << File.expand_path(File.dirname(__FILE__) + '/../../locales/en.yml')
-            I18n.reload!
-            locale_loaded = true
-        end
-
+        init!
         Provider
       end
 
       command "lxc" do
         require_relative 'command/root'
+        init!
         Command::Root
       end
 
       config(:lxc, :provider) do
         require File.expand_path("../config", __FILE__)
+        init!
         Config
       end
 
@@ -41,6 +36,16 @@ module Vagrant
         require_relative "provider/cap/public_address"
         Provider::Cap::PublicAddress
       end
+
+      protected
+
+      def self.init!
+        return if defined?(@_init)
+        I18n.load_path << File.expand_path(File.dirname(__FILE__) + '/../../locales/en.yml')
+        I18n.reload!
+        @_init = true
+      end
+
     end
   end
 end

--- a/lib/vagrant-lxc/plugin.rb
+++ b/lib/vagrant-lxc/plugin.rb
@@ -8,12 +8,16 @@ module Vagrant
       The LXC provider allows Vagrant to manage and control
       LXC-based virtual machines.
       EOF
+      locale_loaded = false
 
       provider(:lxc, parallel: true, priority: 7) do
         require File.expand_path("../provider", __FILE__)
 
-        I18n.load_path << File.expand_path(File.dirname(__FILE__) + '/../../locales/en.yml')
-        I18n.reload!
+        if not locale_loaded
+            I18n.load_path << File.expand_path(File.dirname(__FILE__) + '/../../locales/en.yml')
+            I18n.reload!
+            locale_loaded = true
+        end
 
         Provider
       end


### PR DESCRIPTION
Hello,
My case is a bit unusual - we have near 200 machines defined by single Vagrantfile.
I found that command 'vagrant status' takes near 82seconds to run on empty setup. With strace I see that there are a lot of  open("...vagrant-lxc-1.2.1/locales/en.yml") requests.
With attached patch time of 'vagrant status' reduced to 32seconds.

Configuration:  
Ubuntu 16.04.1
Vagrant Version: 1.8.5
vagrant plugin list:
 vagrant-lxc (1.2.1)
 vagrant-share (1.1.5, system)
