### PR TITLE
Increase the re-tries amount

### DIFF
--- a/lib/vagrant-lxc/action/fetch_ip_with_lxc_attach.rb
+++ b/lib/vagrant-lxc/action/fetch_ip_with_lxc_attach.rb
@@ -19,9 +19,11 @@ module Vagrant
         end
 
         def assigned_ip(env)
+          config = env[:machine].provider_config
+          fetch_ip_tries = config.fetch_ip_tries
           driver = env[:machine].provider.driver
           ip = ''
-          retryable(:on => LXC::Errors::ExecuteError, :tries => 20, :sleep => 3) do
+          retryable(:on => LXC::Errors::ExecuteError, :tries => fetch_ip_tries, :sleep => 3) do
             unless ip = get_container_ip_from_ip_addr(driver)
               # retry
               raise LXC::Errors::ExecuteError, :command => "lxc-attach"

--- a/lib/vagrant-lxc/action/fetch_ip_with_lxc_attach.rb
+++ b/lib/vagrant-lxc/action/fetch_ip_with_lxc_attach.rb
@@ -21,7 +21,7 @@ module Vagrant
         def assigned_ip(env)
           driver = env[:machine].provider.driver
           ip = ''
-          retryable(:on => LXC::Errors::ExecuteError, :tries => 10, :sleep => 3) do
+          retryable(:on => LXC::Errors::ExecuteError, :tries => 20, :sleep => 3) do
             unless ip = get_container_ip_from_ip_addr(driver)
               # retry
               raise LXC::Errors::ExecuteError, :command => "lxc-attach"

--- a/lib/vagrant-lxc/config.rb
+++ b/lib/vagrant-lxc/config.rb
@@ -26,7 +26,7 @@ module Vagrant
         @backingstore_options = []
         @sudo_wrapper   = UNSET_VALUE
         @container_name = UNSET_VALUE
-        @fetch_ip_tries = 10
+        @fetch_ip_tries = UNSET_VALUE
       end
 
       # Customize the container by calling `lxc-start` with the given
@@ -54,6 +54,7 @@ module Vagrant
         @container_name = nil if @container_name == UNSET_VALUE
         @backingstore = "best" if @backingstore == UNSET_VALUE
         @existing_container_name = nil if @existing_container_name == UNSET_VALUE
+        @fetch_ip_tries = 10 if @fetch_ip_tries == UNSET_VALUE
       end
     end
   end

--- a/lib/vagrant-lxc/config.rb
+++ b/lib/vagrant-lxc/config.rb
@@ -18,12 +18,15 @@ module Vagrant
       # machine name, set this to :machine
       attr_accessor :container_name
 
+      attr_accessor :fetch_ip_tries
+
       def initialize
         @customizations = []
         @backingstore = UNSET_VALUE
         @backingstore_options = []
         @sudo_wrapper   = UNSET_VALUE
         @container_name = UNSET_VALUE
+        @fetch_ip_tries = 10
       end
 
       # Customize the container by calling `lxc-start` with the given


### PR DESCRIPTION
It seems that on slower systems, 30 seconds is not enough to properly get the ip address.



