### PR TITLE
Update pipework regexp for sudo wrapper

### DIFF
--- a/lib/vagrant-lxc/command/sudoers.rb
+++ b/lib/vagrant-lxc/command/sudoers.rb
@@ -48,7 +48,7 @@ module Vagrant
               'sudoers.rb',
               :template_root  => Vagrant::LXC.source_root.join('templates').to_s,
               :cmd_paths      => build_cmd_paths_hash,
-              :pipework_regex => "#{ENV['HOME']}/\.vagrant\.d/gems/gems/vagrant-lxc.+/scripts/pipework"
+              :pipework_regex => "#{ENV['HOME']}/\.vagrant\.d/gems/(?:\\d+?\\.\\d+?\\.\\d+?/)?gems/vagrant-lxc.+/scripts/pipework"
             )
             file.puts template.render
           end


### PR DESCRIPTION
On Vagrant 1.9+ plugin gems are installed into a different folder, their path
containing the ruby version. This updates the regular expression whitelisting
the pipework script to reflect this change.

Ideally there would be some dynamic detection of the correct path, but this
was the easiest fix that worked for me.