### PR TITLE
lxc-template: make runnable by unprivileged users

### DIFF
--- a/scripts/lxc-template
+++ b/scripts/lxc-template
@@ -115,7 +115,6 @@ fi
 # Unpack the rootfs
 echo "Unpacking the rootfs"
 
-mkdir -p /var/lock/subsys
 (
     flock -x 200
     if [ $? -ne 0 ]; then
@@ -124,13 +123,14 @@ mkdir -p /var/lock/subsys
     fi
 
     mkdir -p ${LXC_ROOTFS}
-    (cd ${LXC_ROOTFS} && tar xfz ${LXC_TARBALL} --strip-components=${LXC_STRIP_COMPONENTS} --xattrs --xattrs-include=*)
-    if [ $? -ne 0 ]; then
+    (cd ${LXC_ROOTFS} && tar xfz ${LXC_TARBALL} --strip-components=${LXC_STRIP_COMPONENTS} --xattrs --xattrs-include=* || true)
+    if [ ! -f ${LXC_ROOTFS}/bin/true ]; then
         echo "Failed to extract rootfs"
         exit 1
     fi
 
-) 200>/var/lock/subsys/lxc
+) 200>${LXC_PATH}/vagrant_lock
+rm ${LXC_PATH}/vagrant_lock
 
 mkdir -p ${LXC_ROOTFS}/dev/pts/
 


### PR DESCRIPTION
lxc-template needlessly require root privileges in two places:

1. lock file location for `flock`
2. failing on `tar` failure during rootfs extraction

For `flock`, it's not necessary that the lock file be in `/var/lock`, it
can be anywhere. Why not put it in `LXC_PATH`?

For the failing `tar` thing, that's because some device are created with
`mknod` which unprivileged users can't do. These device, however, are
not necessary for the container to run well. We can ignore `tar`'s error
exit code.

I replaced the exist code check by a check for the existence of
`/bin/true` in rootfs. I think that it's a good indication of whether
the rootfs was extracted.

Why am I making this change? Because I'd like to add support for
unprivileged containers in `vagrant-lxc` but it's kind of a big change
to make at once, so I thought I'd go incrementally.