### PR TITLE
Fix for #336

### DIFF
--- a/lib/vagrant-lxc/errors.rb
+++ b/lib/vagrant-lxc/errors.rb
@@ -16,6 +16,15 @@ module Vagrant
         end
       end
 
+      # Raised when user interrupts a subprocess
+      class SubprocessInterruptError < Vagrant::Errors::VagrantError
+        error_key(:lxc_interrupt_error)
+        def initialize(message, *args)
+          super
+        end
+      end
+
+
       class NamespacesNotSupported < Vagrant::Errors::VagrantError
       end
 

--- a/lib/vagrant-lxc/sudo_wrapper.rb
+++ b/lib/vagrant-lxc/sudo_wrapper.rb
@@ -59,7 +59,7 @@ module Vagrant
           # nicely handled by Vagrant.
           if r.exit_code != 0
             if @interrupted
-              @logger.info("Exit code != 0, but interrupted. Ignoring.")
+              raise LXC::Errors::SubprocessInterruptError, command.inspect
             else
               raise LXC::Errors::ExecuteError,
                 command: command.inspect, stderr: r.stderr, stdout: r.stdout, exitcode: r.exit_code

--- a/locales/en.yml
+++ b/locales/en.yml
@@ -40,6 +40,9 @@ en:
           preparing: Setting up mount entries for shared folders...
 
     errors:
+      lxc_interrupt_error: |-
+        Interrupted
+
       lxc_execute_error: |-
         There was an error executing %{command}
 


### PR DESCRIPTION
Subprocessed being interrupted resulted in it looking
like those commands were executing successfully but with
zero output.  Interrupting the sudo prompt would result
in any command running in sudo returning nothing and looking
like it had succeeded.  There was some clean up code in
the lxc provider that nuked vagrant container state in
the .vagrant directory if it looked like the container no
longer existed based on the result of lxc-ls.  Interrupting
this check resulted in it looking like the container not
existing, resulting in the provider code nuking the lxc dir
in .vagrant.  Voila