### PR TITLE
updated utsname to uts.name

### DIFF
--- a/lib/vagrant-lxc/action/boot.rb
+++ b/lib/vagrant-lxc/action/boot.rb
@@ -12,7 +12,7 @@ module Vagrant
           config = env[:machine].provider_config
 
           utsname = env[:machine].config.vm.hostname || env[:machine].id
-          config.customize 'utsname', utsname
+          config.customize 'uts.name', utsname
 
           # Fix apparmor issues when starting Ubuntu 14.04 containers
           # See https://github.com/fgrehm/vagrant-lxc/issues/278 for more information

--- a/scripts/lxc-template
+++ b/scripts/lxc-template
@@ -144,7 +144,7 @@ if [ -e "${LXC_PATH}/config-auto" ]; then
     cat ${LXC_PATH}/config-auto >> ${LXC_PATH}/config
     rm ${LXC_PATH}/config-auto
 fi
-echo "lxc.utsname = ${LXC_NAME}" >> ${LXC_PATH}/config
+echo "lxc.uts.name = ${LXC_NAME}" >> ${LXC_PATH}/config
 
 ## Re-add the previously removed network config
 if [ -e "${LXC_PATH}/config-network" ]; then


### PR DESCRIPTION
I will surely not be the only one running into this so I thought a quick pr would be useful
a few keys have been updated with LXC 3.0

this specific one affects vagrant-lxc