### PR TITLE
Fix redir version fetching.

### DIFF
--- a/lib/vagrant-lxc/action/forward_ports.rb
+++ b/lib/vagrant-lxc/action/forward_ports.rb
@@ -108,7 +108,7 @@ module Vagrant
         def redir_version
           stdout, stderr, _ = Open3.capture3 "redir --version"
           # For some weird reason redir printed version information in STDERR prior to 3.2
-          version = stdout || stderr
+          version = stdout.empty? ? stderr : stdout
           version.split('.')[0].to_i
         end
 


### PR DESCRIPTION
`"" || "something"` doesn't really work. Have to check for the actual string
length to determine if got something or not out of the pipe.

`redir` version was updated on AUR (archlinux) recently from 2.* to 3.* and this broke. 