### PR TITLE
Fix pipework for lxc-3.1.0.

### DIFF
--- a/scripts/pipework
+++ b/scripts/pipework
@@ -154,7 +154,8 @@ done < /proc/mounts
 }
 
 # Try to find a cgroup matching exactly the provided name.
-N=$(find "$CGROUPMNT" -name "$GUESTNAME" | wc -l)
+M=$(find "$CGROUPMNT" -name "$GUESTNAME")
+N=$(echo "$M" | wc -l)
 case "$N" in
   0)
     # If we didn't find anything, try to lookup the container with Docker.
@@ -179,6 +180,9 @@ case "$N" in
     fi
     ;;
   1) true ;;
+  2)  # LXC >=3.1.0 returns two entries from the cgroups mount instead of one.
+      echo "$M" | grep -q "lxc\.monitor" || die 1 "Found more than one container matching $GUESTNAME."
+      ;;
   *) die 1 "Found more than one container matching $GUESTNAME." ;;
 esac
 


### PR DESCRIPTION
LXC 3.1.0 mounts two entries in cgroups now instead of one. The code expected one entry to be returned at all times.

Added a simple check for this particular case.