### PR TITLE
Truncate config on writes

### DIFF
--- a/lib/vagrant-lxc/driver.rb
+++ b/lib/vagrant-lxc/driver.rb
@@ -270,7 +270,7 @@ module Vagrant
       def write_config(contents)
         confpath = base_path.join('config').to_s
         begin
-          File.open(confpath, File::RDWR) do |file|
+          File.open(confpath, File::WRONLY|File::TRUNC) do |file|
             file.write contents
           end
         rescue


### PR DESCRIPTION
Fixes #485. As per https://apidock.com/ruby/IO/open/class `File::RDWR` seems to lack `File::TRUNC`. Hence the call from `prune_customizations` did nothing since it just overwrite the start of the file (which is presumably already untouched), but left the `VAGRANT-BEGIN/VAGRANT-END` block that followed completely untouched.

By adding `File::TRUNC`, `prune_customizations` will cause those tailing blocks to be removed as intended.