### PR TITLE
fix: resolve issues with cgroup2 and lxc4

### DIFF
--- a/scripts/pipework
+++ b/scripts/pipework
@@ -144,9 +144,12 @@ CONTAINER_IFNAME=${CONTAINER_IFNAME:-eth1}
 
 # Second step: find the guest (for now, we only support LXC containers)
 while read _ mnt fstype options _; do
-  [ "$fstype" != "cgroup" ] && continue
-  echo "$options" | grep -qw devices || continue
+  [ "$fstype" != "cgroup2" ] && [ "$fstype" != "cgroup" ] && continue
+  if [ "$fstype" = "cgroup" ]; then
+    echo "$options" | grep -qw devices || continue
+  fi
   CGROUPMNT=$mnt
+  CGROUPTYPE=$fstype
 done < /proc/mounts
 
 [ "$CGROUPMNT" ] || {
@@ -154,7 +157,9 @@ done < /proc/mounts
 }
 
 # Try to find a cgroup matching exactly the provided name.
-N=$(find "$CGROUPMNT" -name "$GUESTNAME" | wc -l)
+[ "$CGROUPTYPE" = "cgroup" ] && N=$(find "$CGROUPMNT" -name "$GUESTNAME" | wc -l)
+[ "$CGROUPTYPE" = "cgroup2" ] && N=$(find "$CGROUPMNT" -name "lxc.payload.$GUESTNAME" | wc -l)
+
 case "$N" in
   0)
     # If we didn't find anything, try to lookup the container with Docker.
@@ -235,7 +240,8 @@ fi
 if [ "$DOCKERPID" ]; then
   NSPID=$DOCKERPID
 else
-  NSPID=$(head -n 1 "$(find "$CGROUPMNT" -name "$GUESTNAME" | head -n 1)/tasks")
+  NSPATH=$(find "$CGROUPMNT" -name "$GUESTNAME" | head -n 1)
+  [ -f "$NSPATH/tasks" ] && NSPID=$(head -n 1 "$NSPATH/tasks")
   [ "$NSPID" ] || {
     # it is an alternative way to get the pid
     NSPID=$(lxc-info -n  "$GUESTNAME" | grep PID | grep -Eo '[0-9]+')


### PR DESCRIPTION
Here's the patch for lxc >= 4.0.2 that should be able to support both cgroups-v1 and cgroups-v2. It was tested on vagrant 2.2.14 + lxc 4.0.6... and seems to work.

Notes: 
* LXC 3.1.0 mounts two entries in cgroups now instead of one. 
* according to kernel documentation, the "tasks" file was removed from CGROUPMNT in cgroup-v2, thus we have to use the lxc-info fallback to get the pid.
