### PR TITLE
fix: make Travis CI usable after the change of GitHub naming scheme for branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
+---
 language: ruby
 rvm:
-  - 2.2
-  - 2.3
-  - 2.4
   - 2.5
+  - 2.6
+  - 2.7
 install:
-  - gem install -v 1.12.5 bundler
-  - bundle _1.12.5_ install --jobs=3 --retry=3
+  - gem install -v 1.16.2 bundler
+  - bundle _1.16.2_ install --jobs=3 --retry=3
 script: "bundle exec rake ci"

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 group :development do
-  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git'
+  gem 'vagrant', git: 'https://github.com/mitchellh/vagrant.git', branch: 'main'
   gem 'guard'
   gem 'guard-rspec'
   gem 'rb-inotify'
@@ -11,7 +11,7 @@ group :development, :test do
   gem 'rake', '~> 10.4.2'
   gem 'rspec', '~> 3.5.0'
   gem 'coveralls', '~> 0.7.2', require: (ENV['COVERAGE'] == 'true')
-  gem 'vagrant-spec', git: 'https://github.com/mitchellh/vagrant-spec.git'
+  gem 'vagrant-spec', git: 'https://github.com/mitchellh/vagrant-spec.git', branch: 'main'
 end
 
 group :plugins do


### PR DESCRIPTION
Hi,

This pull request fixes the following issues related to Travis CI :
* broken `bundle install` occurring since Github changed their naming scheme for branches (master => main) ;
* broken `bundle install` because of outdated dependencies (not matching requirements for vagrant v2.2.17)

![image](https://user-images.githubusercontent.com/81168/117076656-072b0b00-ad37-11eb-8541-7389a3c8fba5.png)

Successful builds here: 
* https://travis-ci.com/github/glenux/vagrant-lxc/jobs/502987303
* https://travis-ci.com/github/glenux/vagrant-lxc/jobs/502987304
* https://travis-ci.com/github/glenux/vagrant-lxc/jobs/502987305
