### PR TITLE
fetch_ip_with_lxc_info added support for ipv6 only network.

### DIFF
--- a/lib/vagrant-lxc/action/fetch_ip_with_lxc_info.rb
+++ b/lib/vagrant-lxc/action/fetch_ip_with_lxc_info.rb
@@ -34,7 +34,7 @@ module Vagrant
         # From: https://github.com/lxc/lxc/blob/staging/src/python-lxc/lxc/__init__.py#L371-L385
         def get_container_ip_from_ip_addr(driver)
           output = driver.info '-iH'
-          if output =~ /^([0-9.]+)/
+          if output =~ /^([0-9.a-f:]+)/
             return $1.to_s
           end
         end


### PR DESCRIPTION
Add support for IPv6 only network to fetch_ip_with_lxc_info.rb